### PR TITLE
board_panda: correctly configure the ehci fref_clkout

### DIFF
--- a/board_panda.c
+++ b/board_panda.c
@@ -6,6 +6,29 @@
 
 void board_late_init(void)
 {
+	if (readl(0x4805D138) & (1<<22)) {
+		/* enable software ioreq */
+		sr32(0x4A30a31C, 8, 1, 0x1);
+		/* set for sys_clk (38.4MHz) */
+		sr32(0x4A30a31C, 1, 2, 0x0);
+		/* set divisor to 2 */
+		sr32(0x4A30a31C, 16, 4, 0x1);
+		/* set the clock source to active */
+		sr32(0x4A30a110, 0, 1, 0x1);
+		/* enable clocks */
+		sr32(0x4A30a110, 2, 2, 0x3);
+	} else {
+		/* enable software ioreq */
+		sr32(0x4A30a314, 8, 1, 0x1);
+		/* set for PER_DPLL */
+		sr32(0x4A30a314, 1, 2, 0x2);
+		/* set divisor to 16 */
+		sr32(0x4A30a314, 16, 4, 0xf);
+		/* set the clock source to active */
+		sr32(0x4A30a110, 0, 1, 0x1);
+		/* enable clocks */
+		sr32(0x4A30a110, 2, 2, 0x3);
+	}
 }
 
 void board_mux_init(void)


### PR DESCRIPTION
This is necessary to make EHCI to work on Pandaboard.

Signed-off-by: Ricardo Salveti de Araujo ricardo.salveti@linaro.org
