### PR TITLE
Backport silicon version detection from x-loader and sdram initialization

### DIFF
--- a/aboot.c
+++ b/aboot.c
@@ -49,7 +49,7 @@ int load_image(unsigned device, unsigned start, unsigned count, void *data)
 	u32 base;
 	int z;
 
-	if (get_omap_rev() >= OMAP_4460_ES1_DOT_0)
+	if (get_omap_rev() >= OMAP4460_ES1_0)
 		base = PUBLIC_API_BASE_4460;
 	else
 		base = PUBLIC_API_BASE_4430;

--- a/arch/omap4/clock.c
+++ b/arch/omap4/clock.c
@@ -37,82 +37,293 @@
 #include <aboot/aboot.h>
 #include <aboot/io.h>
 #include <omap4/hw.h>
-
-
-//#include <omap4/clocks.h>
-
-#define LDELAY      12000000
-
-#define PLL_STOP		1 /* PER & IVA */
-#define PLL_MN_POWER_BYPASS	4
-#define PLL_LOW_POWER_BYPASS	5 /* MPU, IVA & CORE */
-#define PLL_FAST_RELOCK_BYPASS	6 /* CORE */
-#define PLL_LOCK		7 /* MPU, IVA, CORE & PER */
-
-#define BIT0 (1<<0)
-#define BIT16 (1<<16)
-#define BIT17 (1<<17)
-#define BIT18 (1<<18)
+#include <omap4/clocks.h>
+#include <omap4/bits.h>
 
 #define CONFIG_OMAP4_SDC 1
 
-/* clk sel is 12M / 13M / 16.8M / 19.2M / 26M / 27M / 38.4M */
-/* we only support 38.4M here */
+/* Tables having M,N,M2 et al values for different sys_clk speeds
+ * This table is generated only for OPP100
+ * The tables are organized as follows:
+ * Rows : 1 - 12M, 2 - 13M, 3 - 16.8M, 4 - 19.2M, 5 - 26M, 6 - 27M, 7 - 38.4M
+ */
 
-#define CONFIG_MPU_1000 1
-
-struct dpll_param mpu_dpll_param = {
-#ifdef CONFIG_MPU_600
-	0x7d, 0x07, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
-#elif CONFIG_MPU_1000
-	0x69, 0x03, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
-#else /* 400MHz */
-	0x1a, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,	
-#endif
+/* MPU parameters */
+struct dpll_param mpu_dpll_param_1008mhz[7] = {
+	/* 12M values */
+	{0x54, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 13M values */
+	{0x3f0, 0xc, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 16.8M values */
+	{0x3c, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 19.2M values */
+	{0x69, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 26M values */
+	{0x1f8, 0xc, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 27M values */
+	{0x70, 0x2, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 38.4M values */
+	/* RUN MPU @ 1008 MHz */
+	{0x69, 0x3, 0x1, 0x00, 0x00, 0x00, 0x00, 0x00},
 };
 
-const struct dpll_param per_dpll_param = {
-	0x14, 0x00, 0x08, 0x06, 0x0c, 0x09, 0x04, 0x05,
+struct dpll_param mpu_dpll_param_920mhz[7] = {
+        /* 12M values */
+        {0xe6, 0x2, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 13M values */
+        {0x398, 0xc, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 16.8M values */
+        {0xdb, 0x3, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 19.2M values */
+        {0x23f, 0xb, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 26M values */
+        {0x1cc, 0xc, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 27M values */
+        {0x398, 0x1a, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 38.4M values */
+        /* RUN MPU @ 920 MHz */
+	{0x23f, 0x17, 0x1, 0x00, 0x00, 0x00, 0x00, 0x00},
 };
 
-struct dpll_param iva_dpll_param = {
+struct dpll_param mpu_dpll_param_600mhz[7] = {
+        /* 12M values */
+        {0x32, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 13M values */
+        {0x258, 0xc, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 16.8M values */
+        {0xfa, 0x6, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 19.2M values */
+        {0x7d, 0x3, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 26M values */
+        {0x12c, 0xc, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 27M values */
+        {0xc8, 0x8, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 38.4M values */
+        /* RUN MPU @ 1.2 GHz */
+        {0x7d, 0x07, 0x1, 0x00, 0x00, 0x00, 0x00, 0x00},
+};
+
+struct dpll_param mpu_dpll_param_1_5ghz[7] = {
+        /* 12M values */
+        {0x7d, 0x1, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 13M values */
+        {0x2ee, 0xc, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 16.8M values */
+        {0x271, 0xd, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 19.2M values */
+        {0x271, 0xf, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 26M values */
+        {0x177, 0xc, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 27M values */
+        {0xfa, 0x8, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+        /* 38.4M values */
+        /* RUN MPU @ 1.5 GHz */
+        {0x271, 0x1f, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00},
+};
+
+/* PER parameters */
+const struct dpll_param per_dpll_param[7] = {
+	/* 12M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 13M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 16.8M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 19.2M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 26M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 27M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 38.4M values */
+	{0x14, 0x00, 0x08, 0x06, 0x0c, 0x09, 0x04, 0x05},
+};
+
+/* IVA parameters */
+struct dpll_param iva_dpll_param[7] = {
+	/* 12M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 13M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 16.8M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 19.2M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 26M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 27M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 38.4M values */
 #ifdef CONFIG_OMAP4_SDC
-	0x61, 0x03, 0x00, 0x00, 0x04, 0x07, 0x00, 0x00,
+	{0x61, 0x03, 0x00, 0x00, 0x04, 0x07, 0x00, 0x00},
 #else
-	0x61, 0x03, 0x00, 0x00, 0x04, 0x07, 0x00, 0x00,
+	{0x61, 0x03, 0x00, 0x00, 0x04, 0x07, 0x00, 0x00},
 #endif
 };
 
-struct dpll_param core_dpll_param_ddr400mhz = {
-	0x7d, 0x05, 0x01, 0x05, 0x08, 0x04, 0x06, 0x05,
+/* CORE parameters */
+struct dpll_param core_dpll_param[7] = {
+	/* 12M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 13M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 16.8M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 19.2M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 26M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 27M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 38.4M values - DDR@200MHz*/
+	{0x7d, 0x05, 0x02, 0x05, 0x08, 0x04, 0x06, 0x05},
 };
 
-struct dpll_param abe_dpll_param = {
+/* CORE parameters */
+struct dpll_param core_dpll_param_ddr400[7] = {
+	/* 12M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 13M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 16.8M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 19.2M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 26M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 27M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 38.4M values - DDR@400MHz*/
+	{0x7d, 0x05, 0x01, 0x05, 0x08, 0x04, 0x06, 0x05},
+};
+
+/* CORE parameters for L3 at 190 MHz - For ES1 only*/
+struct dpll_param core_dpll_param_l3_190[7] = {
+	/* 12M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 13M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 16.8M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 19.2M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 26M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 27M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 38.4M values */
+#ifdef CORE_190MHZ 
+	{0x1f0, 0x18, 0x01, 0x05, 0x08, 0x04, 0x06, 0x05},
+#else /* Default CORE @166MHz */
+	{0x1b0, 0x18, 0x01, 0x05, 0x08, 0x04, 0x06, 0x05},
+#endif
+};
+
+/*
+ * ABE parameters
+ *
+ * By default DPLL_ABE is driven from 32KHz clock.  To drive it from SYS_CK
+ * set CONFIG_OMAP4_ABE_SYSCK
+ */
+struct dpll_param abe_dpll_param[7] = {
+	/* 12M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 13M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 16.8M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 19.2M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 26M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 27M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 38.4M values */
+#ifdef CONFIG_OMAP4_ABE_SYSCK
+	{0x40, 0x18, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0},
+#else
+	{0x2ee, 0x0, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0},
+#endif
+};
+
+/* USB parameters */
+struct dpll_param usb_dpll_param[7] = {
+	/* 12M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 13M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 16.8M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 19.2M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 26M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 27M values */
+	{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	/* 38.4M values */
 #ifdef CONFIG_OMAP4_SDC
-	0x40, 0x18, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0,
+	{0x32, 0x1, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4},
 #else
-	0x40, 0x18, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0,
+	{0x32, 0x1, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4},
 #endif
 };
-
-struct dpll_param usb_dpll_param = {
-#ifdef CONFIG_OMAP4_SDC
-	0x32, 0x1, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0,
-#else
-	0x32, 0x1, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0,
-#endif
-};
+/* PER dpll params defined in board file */
+extern const struct dpll_param per_dpll_param[7];
 
 typedef struct dpll_param dpll_param;
 
-static void configure_mpu_dpll(dpll_param *dpll_param_p)
+static void configure_mpu_dpll(u32 clk_index)
 {
+	dpll_param *dpll_param_p;
+	u32 omap4_rev, emif_div_4 = 0, abe_div_8 = 0, dcc_en = 0;
+
+	omap4_rev = get_omap_rev();
+
 	/* Unlock the MPU dpll */
 	sr32(CM_CLKMODE_DPLL_MPU, 0, 3, PLL_MN_POWER_BYPASS);
 	wait_on_value(BIT0, 0, CM_IDLEST_DPLL_MPU, LDELAY);
 
-	/* Disable DPLL autoidle */
-	sr32(CM_AUTOIDLE_DPLL_MPU, 0, 3, 0x0);
+	if (omap4_rev >= OMAP4460_ES1_0) {
+
+		switch (omap4_silicon_type()) {
+#if 0
+			case PROD_ID_1_SILICON_TYPE_STD_PERF:
+				/*
+				 * Same M, N as for 600 MHz from M2 output will
+				 * give 1200 MHz from M3 output
+				 */
+				dpll_param_p = &mpu_dpll_param_600mhz[clk_index];
+				dcc_en = 1;
+				emif_div_4 = 1;
+				abe_div_8 = 1;
+				break;
+			case PROD_ID_1_SILICON_TYPE_HIGH_PERF:
+				dpll_param_p = &mpu_dpll_param_1_5ghz[clk_index];
+				dcc_en = 1;
+				emif_div_4 = 1;
+				abe_div_8 = 1;
+				break;
+#endif
+			default:
+				dpll_param_p = &mpu_dpll_param_920mhz[clk_index];
+				emif_div_4 = 0;
+				abe_div_8 = 1;
+				break;
+		}
+
+		sr32(CM_MPU_MPU_CLKCTRL, 24, 1, emif_div_4);
+		sr32(CM_MPU_MPU_CLKCTRL, 25, 1, abe_div_8);
+
+		/* Enable / disable DCC on 4460 */
+		sr32(CM_CLKSEL_DPLL_MPU, 22, 1, dcc_en);
+
+	} else if (omap4_rev > OMAP4430_ES1_0) {
+		dpll_param_p = &mpu_dpll_param_1008mhz[clk_index];
+	} else {
+		dpll_param_p = &mpu_dpll_param_600mhz[clk_index];
+	}
+
+	sr32(CM_AUTOIDLE_DPLL_MPU, 0, 3, 0x0); /* Disable DPLL autoidle */
 
 	/* Set M,N,M2 values */
 	sr32(CM_CLKSEL_DPLL_MPU, 8, 11, dpll_param_p->m);
@@ -123,10 +334,14 @@ static void configure_mpu_dpll(dpll_param *dpll_param_p)
 	/* Lock the mpu dpll */
 	sr32(CM_CLKMODE_DPLL_MPU, 0, 3, PLL_LOCK | 0x10);
 	wait_on_value(BIT0, 1, CM_IDLEST_DPLL_MPU, LDELAY);
+
+	return;
 }
 
-static void configure_iva_dpll(dpll_param *dpll_param_p)
+static void configure_iva_dpll(u32 clk_index)
 {
+	dpll_param *dpll_param_p;
+
 	/* Unlock the IVA dpll */
 	sr32(CM_CLKMODE_DPLL_IVA, 0, 3, PLL_MN_POWER_BYPASS);
 	wait_on_value(BIT0, 0, CM_IDLEST_DPLL_IVA, LDELAY);
@@ -134,8 +349,10 @@ static void configure_iva_dpll(dpll_param *dpll_param_p)
 	/* CM_BYPCLK_DPLL_IVA = CORE_X2_CLK/2 */
 	sr32(CM_BYPCLK_DPLL_IVA, 0, 2, 0x1);
 
-	/* Disable DPLL autoidle */
-	sr32(CM_AUTOIDLE_DPLL_IVA, 0, 3, 0x0);
+	/* Program IVA DPLL */
+	dpll_param_p = &iva_dpll_param[clk_index];
+
+	sr32(CM_AUTOIDLE_DPLL_IVA, 0, 3, 0x0); /* Disable DPLL autoidle */
 
 	/* Set M,N,M4,M5 */
 	sr32(CM_CLKSEL_DPLL_IVA, 8, 11, dpll_param_p->m);
@@ -148,13 +365,20 @@ static void configure_iva_dpll(dpll_param *dpll_param_p)
 	/* Lock the iva dpll */
 	sr32(CM_CLKMODE_DPLL_IVA, 0, 3, PLL_LOCK);
 	wait_on_value(BIT0, 1, CM_IDLEST_DPLL_IVA, LDELAY);
+
+	return;
 }
 
-static void configure_per_dpll(const dpll_param *dpll_param_p)
+static void configure_per_dpll(u32 clk_index)
 {
+	const dpll_param *dpll_param_p;
+
 	/* Unlock the PER dpll */
 	sr32(CM_CLKMODE_DPLL_PER, 0, 3, PLL_MN_POWER_BYPASS);
 	wait_on_value(BIT0, 0, CM_IDLEST_DPLL_PER, LDELAY);
+
+	/* Program PER DPLL */
+	dpll_param_p = &per_dpll_param[clk_index];
 
 	/* Disable autoidle */
 	sr32(CM_AUTOIDLE_DPLL_PER, 0, 3, 0x0);
@@ -177,22 +401,51 @@ static void configure_per_dpll(const dpll_param *dpll_param_p)
 	/* Lock the per dpll */
 	sr32(CM_CLKMODE_DPLL_PER, 0, 3, PLL_LOCK);
 	wait_on_value(BIT0, 1, CM_IDLEST_DPLL_PER, LDELAY);
+
+	return;
 }
 
-static void configure_abe_dpll(dpll_param *dpll_param_p)
+/* DPLL_ABE is driven by 32KHz timer by default */
+static void configure_abe_dpll(u32 clk_index)
 {
-	/* Select sys_clk as ref clk for ABE dpll */
+	dpll_param *dpll_param_p;
+	u32 clkmode_value;
+
+#ifdef CONFIG_OMAP4_ABE_SYSCK
 	sr32(CM_ABE_PLL_REF_CLKSEL, 0, 32, 0x0);
+#endif
 
 	/* Unlock the ABE dpll */
 	sr32(CM_CLKMODE_DPLL_ABE, 0, 3, PLL_MN_POWER_BYPASS);
 	wait_on_value(BIT0, 0, CM_IDLEST_DPLL_ABE, LDELAY);
 
+	/* Program ABE DPLL */
+	dpll_param_p = &abe_dpll_param[clk_index];
+
 	/* Disable autoidle */
 	sr32(CM_AUTOIDLE_DPLL_ABE, 0, 3, 0x0);
 
+	/*
+	 * Enable higher frequencies when fed from 32KHz clk.  Sets
+	 * DPLL_REGM4XEN, DPLL_LPMODE, DPLL_RELOCK_RAMP_EN, DPLL_RAMP_RATE and
+	 * DPLL_DRIFTGUARD_EN in the CM_CLKMODE_DPLL_ABE register.
+	 *
+	 * Public TRM does not cover all of this: DPLL_RAMP_RATE (bit 5)
+	 * selects time spent at each stage of clock ramping process.  We
+	 * spend 4 REFCLKs.  DPLL_RELOCK_RAMP_EN (bit 9) enables the clock
+	 * ramping feature, using the rate specified in DPLL_RAMP_RATE.
+	 *
+	 * Also the DPLL_REGM4XEN bit provides a magic 4x multplier to
+	 * existing MN dividers.  This is how a DPLL driven from 32KHz clock
+	 * can achieve 196.608MHz.
+	 */
+#ifndef CONFIG_OMAP4_ABE_SYSCK
+	clkmode_value = (BIT5 | BIT8 | BIT9 | BIT10 | BIT11);
+	sr32(CM_CLKMODE_DPLL_ABE, 0, 12, clkmode_value);
+#endif
+
 	sr32(CM_CLKSEL_DPLL_ABE, 8, 11, dpll_param_p->m);
-	sr32(CM_CLKSEL_DPLL_ABE, 0, 6, dpll_param_p->n);
+	sr32(CM_CLKSEL_DPLL_ABE, 0, 7, dpll_param_p->n);
 
 	/* Force DPLL CLKOUTHIF to stay enabled */
 	sr32(CM_DIV_M2_DPLL_ABE, 0, 32, 0x500);
@@ -206,10 +459,14 @@ static void configure_abe_dpll(dpll_param *dpll_param_p)
 	/* Lock the abe dpll */
 	sr32(CM_CLKMODE_DPLL_ABE, 0, 3, PLL_LOCK);
 	wait_on_value(BIT0, 1, CM_IDLEST_DPLL_ABE, LDELAY);
+
+	return;
 }
 
-static void configure_usb_dpll(dpll_param *dpll_param_p)
+static void configure_usb_dpll(u32 clk_index)
 {
+	dpll_param *dpll_param_p;
+
 	/* Select the 60Mhz clock 480/8 = 60*/
 	sr32(CM_CLKSEL_USB_60MHz, 0, 32, 0x1);
 
@@ -217,9 +474,13 @@ static void configure_usb_dpll(dpll_param *dpll_param_p)
 	sr32(CM_CLKMODE_DPLL_USB, 0, 3, PLL_MN_POWER_BYPASS);
 	wait_on_value(BIT0, 0, CM_IDLEST_DPLL_USB, LDELAY);
 
+	/* Program USB DPLL */
+	dpll_param_p = &usb_dpll_param[clk_index];
+
 	/* Disable autoidle */
 	sr32(CM_AUTOIDLE_DPLL_USB, 0, 3, 0x0);
 
+	sr32(CM_CLKSEL_DPLL_USB, 24, 8, dpll_param_p->sd_div);
 	sr32(CM_CLKSEL_DPLL_USB, 8, 11, dpll_param_p->m);
 	sr32(CM_CLKSEL_DPLL_USB, 0, 6, dpll_param_p->n);
 
@@ -235,23 +496,36 @@ static void configure_usb_dpll(dpll_param *dpll_param_p)
 
 	/* force enable the CLKDCOLDO clock */
 	sr32(CM_CLKDCOLDO_DPLL_USB, 0, 32, 0x100);
+
+	return;
 }
 
 void configure_core_dpll_no_lock(void)
 {
-	dpll_param *dpll_param_p = &core_dpll_param_ddr400mhz;
+	dpll_param *dpll_param_p = 0;
+	u32 clk_index;
 
 	/* Get the sysclk speed from cm_sys_clksel
 	 * Set it to 38.4 MHz, in case ROM code is bypassed
 	 */
 	writel(0x7,CM_SYS_CLKSEL);
+	clk_index = 7;
 
+	clk_index = clk_index - 1;
 	/* CORE_CLK=CORE_X2_CLK/2, L3_CLK=CORE_CLK/2, L4_CLK=L3_CLK/2 */
 	sr32(CM_CLKSEL_CORE, 0, 32, 0x110);
 
 	/* Unlock the CORE dpll */
 	sr32(CM_CLKMODE_DPLL_CORE, 0, 3, PLL_MN_POWER_BYPASS);
 	wait_on_value(BIT0, 0, CM_IDLEST_DPLL_CORE, LDELAY);
+
+	/* Program Core DPLL */
+	if(get_omap_rev() == OMAP4430_ES1_0)
+		dpll_param_p = &core_dpll_param_l3_190[clk_index];
+	else if (get_omap_rev() == OMAP4430_ES2_0)
+		dpll_param_p = &core_dpll_param[clk_index];
+	else if (get_omap_rev() >= OMAP4430_ES2_1)
+		dpll_param_p = &core_dpll_param_ddr400[clk_index];
 
 	/* Disable autoidle */
 	sr32(CM_AUTOIDLE_DPLL_CORE, 0, 3, 0x0);
@@ -264,6 +538,19 @@ void configure_core_dpll_no_lock(void)
 	sr32(CM_DIV_M5_DPLL_CORE, 0, 5, dpll_param_p->m5);
 	sr32(CM_DIV_M6_DPLL_CORE, 0, 5, dpll_param_p->m6);
 	sr32(CM_DIV_M7_DPLL_CORE, 0, 5, dpll_param_p->m7);
+
+	if(get_omap_rev() == OMAP4430_ES1_0)
+	{
+		/* Do this only on ES1.0 */
+		sr32(CM_DIV_M2_DPLL_CORE, 8, 1, 0x1);
+		sr32(CM_DIV_M3_DPLL_CORE, 8, 1, 0x1);
+		sr32(CM_DIV_M4_DPLL_CORE, 8, 1, 0x1);
+		sr32(CM_DIV_M5_DPLL_CORE, 8, 1, 0x1);
+		sr32(CM_DIV_M6_DPLL_CORE, 8, 1, 0x1);
+		sr32(CM_DIV_M7_DPLL_CORE, 8, 1, 0x1);
+	}
+
+	return;
 }
 
 void lock_core_dpll(void)
@@ -271,11 +558,14 @@ void lock_core_dpll(void)
 	/* Lock the core dpll */
 	sr32(CM_CLKMODE_DPLL_CORE, 0, 3, PLL_LOCK);
 	wait_on_value(BIT0, 1, CM_IDLEST_DPLL_CORE, LDELAY);
+
+	return;
 }
 
 void lock_core_dpll_shadow(void)
 {
-	dpll_param *dpll_param_p = &core_dpll_param_ddr400mhz;
+	dpll_param *dpll_param_p = 0;
+	u32 clk_index;
 	u32 temp;
 	temp = readl(CM_MEMIF_CLKSTCTRL);
 	temp &= (~3);
@@ -291,6 +581,15 @@ void lock_core_dpll_shadow(void)
 	/* Lock the core dpll using freq update method */
 	/*(CM_CLKMODE_DPLL_CORE) */
 	writel(0x0A, 0x4A004120);
+
+	clk_index = 6;
+
+	if(get_omap_rev() == OMAP4430_ES1_0)
+		dpll_param_p = &core_dpll_param_l3_190[clk_index];
+	else if (get_omap_rev() == OMAP4430_ES2_0)
+		dpll_param_p = &core_dpll_param[clk_index];
+	else if (get_omap_rev() >= OMAP4430_ES2_1)
+		dpll_param_p = &core_dpll_param_ddr400[clk_index];
 
 	/* CM_SHADOW_FREQ_CONFIG1: DLL_OVERRIDE = 1(hack), DLL_RESET = 1,
 	 * DPLL_CORE_M2_DIV =1, DPLL_CORE_DPLL_EN = 0x7, FREQ_UPDATE = 1
@@ -312,10 +611,74 @@ void lock_core_dpll_shadow(void)
 		;
 
 	writel(temp|3, CM_MEMIF_CLKSTCTRL);
+	return;
 }
 
 static void enable_all_clocks(void)
 {
+	if (get_omap_rev() == OMAP4430_ES1_0) {
+		/* Enable Ducati clocks */
+		sr32(CM_DUCATI_DUCATI_CLKCTRL, 0, 32, 0x1);
+		sr32(CM_DUCATI_CLKSTCTRL, 0, 32, 0x2);
+
+		wait_on_value(BIT8, BIT8, CM_DUCATI_CLKSTCTRL, LDELAY);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM_DUCATI_DUCATI_CLKCTRL, LDELAY);
+
+		/* Enable ivahd and sl2 clocks */
+		sr32(IVAHD_IVAHD_CLKCTRL, 0, 32, 0x1);
+		sr32(IVAHD_SL2_CLKCTRL, 0, 32, 0x1);
+		sr32(IVAHD_CLKSTCTRL, 0, 32, 0x2);
+
+		wait_on_value(BIT8, BIT8, IVAHD_CLKSTCTRL, LDELAY);
+
+		/* wait for ivahd to become accessible */
+		//wait_on_value(BIT18|BIT17|BIT16, 0, IVAHD_IVAHD_CLKCTRL, LDELAY);
+		/* wait for sl2 to become accessible */
+		//wait_on_value(BIT17|BIT16, 0, IVAHD_SL2_CLKCTRL, LDELAY);
+
+		/* Enable Tesla clocks */
+		sr32(DSP_DSP_CLKCTRL, 0, 32, 0x1);
+		sr32(DSP_CLKSTCTRL, 0, 32, 0x2);
+
+		wait_on_value(BIT8, BIT8, DSP_CLKSTCTRL, LDELAY);
+
+		/* wait for tesla to become accessible */
+		//wait_on_value(BIT18|BIT17|BIT16, 0, DSP_DSP_CLKCTRL, LDELAY);
+
+		/* TODO: Some hack needed by MM: Clean this */
+
+		/* ABE clocks */
+		sr32(CM1_ABE_CLKSTCTRL, 0, 32, 0x3);
+		sr32(CM1_ABE_AESS_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM1_ABE_AESS_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_PDM_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_PDM_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_DMIC_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_DMIC_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_MCASP_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_MCASP_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_MCBSP1_CLKCTRL, 0, 32, 0x08000002);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_MCBSP1_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_MCBSP2_CLKCTRL, 0, 32, 0x08000002);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_MCBSP2_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_MCBSP3_CLKCTRL, 0, 32, 0x08000002);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_MCBSP3_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_SLIMBUS_CLKCTRL, 0, 32, 0xf02);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_SLIMBUS_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_TIMER5_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_TIMER5_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_TIMER6_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_TIMER6_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_TIMER7_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_TIMER7_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_TIMER8_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_TIMER8_CLKCTRL, LDELAY);
+		sr32(CM1_ABE_WDT3_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT17|BIT16, 0, CM1_ABE_WDT3_CLKCTRL, LDELAY);
+		/* Disable sleep transitions */
+		sr32(CM1_ABE_CLKSTCTRL, 0, 32, 0x0);
+	}
+
 	/* L4PER clocks */
 	sr32(CM_L4PER_CLKSTCTRL, 0, 32, 0x2);
 	sr32(CM_L4PER_DMTIMER10_CLKCTRL, 0, 32, 0x2);
@@ -422,6 +785,56 @@ static void enable_all_clocks(void)
 	sr32(CM_WKUP_WDT2_CLKCTRL, 0, 32, 0x2);
 	wait_on_value(BIT17|BIT16, 0, CM_WKUP_WDT2_CLKCTRL, LDELAY);
 
+
+	if (get_omap_rev() == OMAP4430_ES1_0) {
+		/* Enable Camera clocks */
+		sr32(CM_CAM_CLKSTCTRL, 0, 32, 0x3);
+		sr32(CM_CAM_ISS_CLKCTRL, 0, 32, 0x102);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM_CAM_ISS_CLKCTRL, LDELAY);
+		sr32(CM_CAM_FDIF_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM_CAM_FDIF_CLKCTRL, LDELAY);
+		sr32(CM_CAM_CLKSTCTRL, 0, 32, 0x0);
+
+		/* Enable DSS clocks */
+		/* PM_DSS_PWRSTCTRL ON State and LogicState = 1 (Retention) */
+		writel(0x7, 0x4A307100);
+		sr32(CM_DSS_CLKSTCTRL, 0, 32, 0x2);
+		sr32(CM_DSS_DSS_CLKCTRL, 0, 32, 0xf02);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM_DSS_DSS_CLKCTRL, LDELAY);
+		sr32(CM_DSS_DEISS_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM_DSS_DEISS_CLKCTRL, LDELAY);
+		/* Check for DSS Clocks */
+		while((readl(0x4A009100) & 0xF00) != 0xE00)
+			;
+		/* Set HW_AUTO transition mode */
+		sr32(CM_DSS_CLKSTCTRL, 0, 32, 0x3);
+
+		/* Enable SGX clocks */
+		sr32(CM_SGX_CLKSTCTRL, 0, 32, 0x2);
+		sr32(CM_SGX_SGX_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM_SGX_SGX_CLKCTRL, LDELAY);
+		/* Check for SGX FCLK and ICLK */
+		while(readl(0x4A009200) != 0x302)
+			;
+		//sr32(CM_SGX_CLKSTCTRL, 0, 32, 0x0);
+		/* Enable hsi/unipro/usb clocks */
+		sr32(CM_L3INIT_HSI_CLKCTRL, 0, 32, 0x1);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM_L3INIT_HSI_CLKCTRL, LDELAY);
+		sr32(CM_L3INIT_UNIPRO1_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM_L3INIT_UNIPRO1_CLKCTRL, LDELAY);
+		sr32(CM_L3INIT_HSUSBHOST_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM_L3INIT_HSUSBHOST_CLKCTRL, LDELAY);
+		sr32(CM_L3INIT_HSUSBOTG_CLKCTRL, 0, 32, 0x1);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM_L3INIT_HSUSBOTG_CLKCTRL, LDELAY);
+		sr32(CM_L3INIT_HSUSBTLL_CLKCTRL, 0, 32, 0x1);
+		//wait_on_value(BIT17|BIT16, 0, CM_L3INIT_HSUSBTLL_CLKCTRL, LDELAY);
+		sr32(CM_L3INIT_FSUSB_CLKCTRL, 0, 32, 0x2);
+		//wait_on_value(BIT18|BIT17|BIT16, 0, CM_L3INIT_FSUSB_CLKCTRL, LDELAY);
+		/* enable the 32K, 48M optional clocks and enable the module */
+		sr32(CM_L3INIT_USBPHY_CLKCTRL, 0, 32, 0x301);
+		//wait_on_value(BIT17|BIT16, 0, CM_L3INIT_USBPHY_CLKCTRL, LDELAY);
+	}
+
 	/* Select DPLL PER CLOCK as source for SGX FCLK */
 	sr32(CM_SGX_SGX_CLKCTRL, 24, 1, 0x1);
 
@@ -429,28 +842,43 @@ static void enable_all_clocks(void)
 	sr32(CM_L3INIT_USBPHY_CLKCTRL, 0, 32, 0x301);
 	sr32(CM_L3INIT_HSUSBOTG_CLKCTRL, 0, 32, 0x1);
 
+	/* Enable DSS clocks:
+	 * In future we want to enable DSS in bootloader to show splash screen
+	 */
+	sr32(PM_DSS_PWRSTCTRL, 0, 2, 0x3);
+	sr32(CM_DSS_CLKSTCTRL, 0, 2, 0x2);
+	sr32(CM_DSS_DSS_CLKCTRL, 0, 11, 0x702);
+
 	return;
 }
 
-/* must be called from sram or flash */
+/******************************************************************************
+ * prcm_init() - inits clocks for PRCM as defined in clocks.h
+ *   -- called from SRAM, or Flash (using temp SRAM stack).
+ *****************************************************************************/
 void prcm_init(void)
 {
 	u32 clk_index;
+
 	/* Get the sysclk speed from cm_sys_clksel
 	 * Set the CM_SYS_CLKSEL in case ROM code has not set
 	 */
 	writel(0x7,CM_SYS_CLKSEL);
 	clk_index = readl(CM_SYS_CLKSEL);
 	if (!clk_index)
-		return;
+		return; /* Sys clk uninitialized */
 
 	/* Configure all DPLL's at 100% OPP */
-	configure_mpu_dpll(&mpu_dpll_param);
-	configure_iva_dpll(&iva_dpll_param);
-	configure_per_dpll(&per_dpll_param);
-	configure_abe_dpll(&abe_dpll_param);
-	configure_usb_dpll(&usb_dpll_param);
+	configure_mpu_dpll(clk_index - 1);
+	configure_iva_dpll(clk_index - 1);
+	configure_per_dpll(clk_index - 1);
+	configure_abe_dpll(clk_index - 1);
+	configure_usb_dpll(clk_index - 1);
 
+#ifdef CONFIG_OMAP4_SDC
+	/* Enable all clocks */
 	enable_all_clocks();
-}
+#endif
 
+	return;
+}

--- a/arch/omap4/id.c
+++ b/arch/omap4/id.c
@@ -30,8 +30,10 @@
 
 #include <aboot/aboot.h>
 #include <aboot/io.h>
+#include <omap4/hw.h>
 
-#define CONTROL_ID_CODE 0x4A002204
+#define get_bit_field(nr, start, mask)\
+	(((nr) & (mask)) >> (start))
 
 unsigned int cortex_a9_rev(void)
 {
@@ -73,4 +75,12 @@ int get_omap_rev(void)
 			return OMAP4430_SILICON_ID_INVALID;
 	}
 
+}
+
+u32 omap4_silicon_type(void)
+{
+	u32 si_type = readl(STD_FUSE_PROD_ID_1);
+	si_type = get_bit_field(si_type, PROD_ID_1_SILICON_TYPE_SHIFT,
+		PROD_ID_1_SILICON_TYPE_MASK);
+	return si_type;
 }

--- a/arch/omap4/rom_usb.c
+++ b/arch/omap4/rom_usb.c
@@ -42,7 +42,7 @@ int usb_open(struct usb *usb)
 	memset(usb, 0, sizeof(*usb));
 
 
-        if (get_omap_rev() >= OMAP_4460_ES1_DOT_0)
+        if (get_omap_rev() >= OMAP4460_ES1_0)
                 base = PUBLIC_API_BASE_4460;
         else
                 base = PUBLIC_API_BASE_4430;

--- a/board_blaze.c
+++ b/board_blaze.c
@@ -239,7 +239,7 @@ void board_mux_init(void)
 	MV1(WK(PAD1_SYS_BOOT7),(IEN|M3)); /*gpio_wk10*/
 	MV1(WK(PAD1_FREF_CLK3_REQ),(M3)); /*gpio_wk30*/
 	MV1(WK(PAD1_FREF_CLK4_REQ),(M3)); /*gpio_wk7*/
-	MV1(WK(PAD0_FREF_CLK4_OUT), (M3)); /*gpio_wk8 */
+	MV1(WK(PAD0_FREF_CLK4_OUT),(M3)); /*gpio_wk8 */
 }
 
 

--- a/board_panda.c
+++ b/board_panda.c
@@ -1,4 +1,31 @@
-
+/*
+ * (C) Copyright 2004-2009
+ * Texas Instruments, <www.ti.com>
+ * Aneesh V	<aneesh@ti.com>
+ *
+ * See file CREDITS for list of people who contributed to this
+ * project.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111-1307 USA
+ */
+/*
+ * All OMAP boards of a given revision todate use the same memory
+ * configuration. So keeping this here instead of keeping in board
+ * directory. If a new board has different memory part/configuration
+ * in future the weakly linked alias for ddr_init() can be over-ridden
+ */
 #include <aboot/aboot.h>
 #include <aboot/io.h>
 #include <omap4/mux.h>
@@ -6,263 +33,369 @@
 
 void board_late_init(void)
 {
+	unsigned int rev = get_omap_rev();
+	if (rev != OMAP4430_ES1_0) {
+		if (readl(0x4805D138) & (1<<22)) {
+			/* enable software ioreq */
+			sr32(0x4A30a31C, 8, 1, 0x1);
+			/* set for sys_clk (38.4MHz) */
+			sr32(0x4A30a31C, 1, 2, 0x0);
+			/* set divisor to 2 */
+			sr32(0x4A30a31C, 16, 4, 0x1);
+			/* set the clock source to active */
+			sr32(0x4A30a110, 0, 1, 0x1);
+			/* enable clocks */
+			sr32(0x4A30a110, 2, 2, 0x3);
+		} else {
+			/* enable software ioreq */
+			sr32(0x4A30a314, 8, 1, 0x1);
+			/* set for PER_DPLL */
+			sr32(0x4A30a314, 1, 2, 0x2);
+			/* set divisor to 16 */
+			sr32(0x4A30a314, 16, 4, 0xf);
+			/* set the clock source to active */
+			sr32(0x4A30a110, 0, 1, 0x1);
+			/* enable clocks */
+			sr32(0x4A30a110, 2, 2, 0x3);
+		}
+	}
 }
 
-void board_mux_init(void)
-{
-	MV(CP(GPMC_AD0) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* sdmmc2_dat0 */
-	MV(CP(GPMC_AD1) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* sdmmc2_dat1 */
-	MV(CP(GPMC_AD2) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* sdmmc2_dat2 */
-	MV(CP(GPMC_AD3) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* sdmmc2_dat3 */
-	MV(CP(GPMC_AD4) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* sdmmc2_dat4 */
-	MV(CP(GPMC_AD5) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* sdmmc2_dat5 */
-	MV(CP(GPMC_AD6) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* sdmmc2_dat6 */
-	MV(CP(GPMC_AD7) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* sdmmc2_dat7 */
-	MV(CP(GPMC_AD8) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M3));  /* gpio_32 */
-	MV(CP(GPMC_AD9) , (PTU | IEN | M3));  /* gpio_33 */
-	MV(CP(GPMC_AD10) , (PTU | IEN | M3));  /* gpio_34 */
-	MV(CP(GPMC_AD11) , (PTU | IEN | M3));  /* gpio_35 */
-	MV(CP(GPMC_AD12) , (PTU | IEN | M3));  /* gpio_36 */
-	MV(CP(GPMC_AD13) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M3));  /* gpio_37 */
-	MV(CP(GPMC_AD14) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M3));  /* gpio_38 */
-	MV(CP(GPMC_AD15) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M3));  /* gpio_39 */
-	MV(CP(GPMC_A16) , (M3));  /* gpio_40 */
-	MV(CP(GPMC_A17) , (PTD | M3));  /* gpio_41 */
-	MV(CP(GPMC_A18) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_row6 */
-	MV(CP(GPMC_A19) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_row7 */
-	MV(CP(GPMC_A20) , (IEN | M3));  /* gpio_44 */
-	MV(CP(GPMC_A21) , (M3));  /* gpio_45 */
-	MV(CP(GPMC_A22) , (M3));  /* gpio_46 */
-	MV(CP(GPMC_A23) , (OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_col7 */
-	MV(CP(GPMC_A24) , (PTD | M3));  /* gpio_48 */
-	MV(CP(GPMC_A25) , (PTD | M3));  /* gpio_49 */
-	MV(CP(GPMC_NCS0) , (M3));  /* gpio_50 */
-	MV(CP(GPMC_NCS1) , (IEN | M3));  /* gpio_51 */
-	MV(CP(GPMC_NCS2) , (IEN | M3));  /* gpio_52 */
-	MV(CP(GPMC_NCS3) , (IEN | M3));  /* gpio_53 */
-	MV(CP(GPMC_NWP) , (M3));  /* gpio_54 */
-	MV(CP(GPMC_CLK) , (PTD | M3));  /* gpio_55 */
-	MV(CP(GPMC_NADV_ALE) , (M3));  /* gpio_56 */
-	MV(CP(GPMC_NOE) , (PTU | IEN | OFF_EN | OFF_OUT_PTD | M1));  /* sdmmc2_clk */
-	MV(CP(GPMC_NWE) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* sdmmc2_cmd */
-	MV(CP(GPMC_NBE0_CLE) , (M3));  /* gpio_59 */
-	MV(CP(GPMC_NBE1) , (PTD | M3));  /* gpio_60 */
-	MV(CP(GPMC_WAIT0) , (PTU | IEN | M3));  /* gpio_61 */
-	MV(CP(GPMC_WAIT1) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M3));  /* gpio_62 */
-	MV(CP(C2C_DATA11) , (PTD | M3));  /* gpio_100 */
-	MV(CP(C2C_DATA12) , (PTU | IEN | M3));  /* gpio_101 */
-	MV(CP(C2C_DATA13) , (PTD | M3));  /* gpio_102 */
-	MV(CP(C2C_DATA14) , ( M1));  /* dsi2_te0 */
-	MV(CP(C2C_DATA15) , (PTD | M3));  /* gpio_104 */
-	MV(CP(HDMI_HPD) , (M0));  /* hdmi_hpd */
-	MV(CP(HDMI_CEC) , (M0));  /* hdmi_cec */
-	MV(CP(HDMI_DDC_SCL) , (PTU | M0));  /* hdmi_ddc_scl */
-	MV(CP(HDMI_DDC_SDA) , (PTU | IEN | M0));  /* hdmi_ddc_sda */
-	MV(CP(CSI21_DX0) , (IEN | M0));  /* csi21_dx0 */
-	MV(CP(CSI21_DY0) , (IEN | M0));  /* csi21_dy0 */
-	MV(CP(CSI21_DX1) , (IEN | M0));  /* csi21_dx1 */
-	MV(CP(CSI21_DY1) , (IEN | M0));  /* csi21_dy1 */
-	MV(CP(CSI21_DX2) , (IEN | M0));  /* csi21_dx2 */
-	MV(CP(CSI21_DY2) , (IEN | M0));  /* csi21_dy2 */
-	MV(CP(CSI21_DX3) , (PTD | M7));  /* csi21_dx3 */
-	MV(CP(CSI21_DY3) , (PTD | M7));  /* csi21_dy3 */
-	MV(CP(CSI21_DX4) , (PTD | OFF_EN | OFF_PD | OFF_IN | M7));  /* csi21_dx4 */
-	MV(CP(CSI21_DY4) , (PTD | OFF_EN | OFF_PD | OFF_IN | M7));  /* csi21_dy4 */
-	MV(CP(CSI22_DX0) , (IEN | M0));  /* csi22_dx0 */
-	MV(CP(CSI22_DY0) , (IEN | M0));  /* csi22_dy0 */
-	MV(CP(CSI22_DX1) , (IEN | M0));  /* csi22_dx1 */
-	MV(CP(CSI22_DY1) , (IEN | M0));  /* csi22_dy1 */
-	MV(CP(CAM_SHUTTER) , (OFF_EN | OFF_PD | OFF_OUT_PTD | M0));  /* cam_shutter */
-	MV(CP(CAM_STROBE) , (OFF_EN | OFF_PD | OFF_OUT_PTD | M0));  /* cam_strobe */
-	MV(CP(CAM_GLOBALRESET) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M3));  /* gpio_83 */
-	MV(CP(USBB1_ULPITLL_CLK) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M4));  /* usbb1_ulpiphy_clk */
-	MV(CP(USBB1_ULPITLL_STP) , (OFF_EN | OFF_OUT_PTD | M4));  /* usbb1_ulpiphy_stp */
-	MV(CP(USBB1_ULPITLL_DIR) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4));  /* usbb1_ulpiphy_dir */
-	MV(CP(USBB1_ULPITLL_NXT) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4));  /* usbb1_ulpiphy_nxt */
-	MV(CP(USBB1_ULPITLL_DAT0) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4));  /* usbb1_ulpiphy_dat0 */
-	MV(CP(USBB1_ULPITLL_DAT1) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4));  /* usbb1_ulpiphy_dat1 */
-	MV(CP(USBB1_ULPITLL_DAT2) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4));  /* usbb1_ulpiphy_dat2 */
-	MV(CP(USBB1_ULPITLL_DAT3) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4));  /* usbb1_ulpiphy_dat3 */
-	MV(CP(USBB1_ULPITLL_DAT4) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4));  /* usbb1_ulpiphy_dat4 */
-	MV(CP(USBB1_ULPITLL_DAT5) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4));  /* usbb1_ulpiphy_dat5 */
-	MV(CP(USBB1_ULPITLL_DAT6) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4));  /* usbb1_ulpiphy_dat6 */
-	MV(CP(USBB1_ULPITLL_DAT7) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4));  /* usbb1_ulpiphy_dat7 */
-	MV(CP(USBB1_HSIC_DATA) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* usbb1_hsic_data */
-	MV(CP(USBB1_HSIC_STROBE) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* usbb1_hsic_strobe */
-	MV(CP(USBC1_ICUSB_DP) , (IEN | M0));  /* usbc1_icusb_dp */
-	MV(CP(USBC1_ICUSB_DM) , (IEN | M0));  /* usbc1_icusb_dm */
-	MV(CP(SDMMC1_CLK) , (PTU | OFF_EN | OFF_OUT_PTD | M0));  /* sdmmc1_clk */
-	MV(CP(SDMMC1_CMD) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc1_cmd */
-	MV(CP(SDMMC1_DAT0) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc1_dat0 */
-	MV(CP(SDMMC1_DAT1) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc1_dat1 */
-	MV(CP(SDMMC1_DAT2) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc1_dat2 */
-	MV(CP(SDMMC1_DAT3) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc1_dat3 */
-	MV(CP(SDMMC1_DAT4) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc1_dat4 */
-	MV(CP(SDMMC1_DAT5) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc1_dat5 */
-	MV(CP(SDMMC1_DAT6) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc1_dat6 */
-	MV(CP(SDMMC1_DAT7) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc1_dat7 */
-	MV(CP(ABE_MCBSP2_CLKX) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* abe_mcbsp2_clkx */
-	MV(CP(ABE_MCBSP2_DR) , (IEN | OFF_EN | OFF_OUT_PTD | M0));  /* abe_mcbsp2_dr */
-	MV(CP(ABE_MCBSP2_DX) , (OFF_EN | OFF_OUT_PTD | M0));  /* abe_mcbsp2_dx */
-	MV(CP(ABE_MCBSP2_FSX) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* abe_mcbsp2_fsx */
-	MV(CP(ABE_MCBSP1_CLKX) , (IEN | M1));  /* abe_slimbus1_clock */
-	MV(CP(ABE_MCBSP1_DR) , (IEN | M1));  /* abe_slimbus1_data */
-	MV(CP(ABE_MCBSP1_DX) , (OFF_EN | OFF_OUT_PTD | M0));  /* abe_mcbsp1_dx */
-	MV(CP(ABE_MCBSP1_FSX) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* abe_mcbsp1_fsx */
-	MV(CP(ABE_PDM_UL_DATA) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* abe_pdm_ul_data */
-	MV(CP(ABE_PDM_DL_DATA) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* abe_pdm_dl_data */
-	MV(CP(ABE_PDM_FRAME) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* abe_pdm_frame */
-	MV(CP(ABE_PDM_LB_CLK) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* abe_pdm_lb_clk */
-	MV(CP(ABE_CLKS) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* abe_clks */
-	MV(CP(ABE_DMIC_CLK1) , (M0));  /* abe_dmic_clk1 */
-	MV(CP(ABE_DMIC_DIN1) , (IEN | M0));  /* abe_dmic_din1 */
-	MV(CP(ABE_DMIC_DIN2),   (PTU | IEN | M3));
-	MV(CP(ABE_DMIC_DIN3) , (IEN | M0));  /* abe_dmic_din3 */
-	MV(CP(UART2_CTS) , (PTU | IEN | M0));  /* uart2_cts */
-	MV(CP(UART2_RTS) , (M0));  /* uart2_rts */
-	MV(CP(UART2_RX) , (PTU | IEN | M0));  /* uart2_rx */
-	MV(CP(UART2_TX) , (M0));  /* uart2_tx */
-	MV(CP(HDQ_SIO) , (M3));  /* gpio_127 */
-	MV(CP(I2C1_SCL) , (PTU | IEN | M0));  /* i2c1_scl */
-	MV(CP(I2C1_SDA) , (PTU | IEN | M0));  /* i2c1_sda */
-	MV(CP(I2C2_SCL) , (PTU | IEN | M0));  /* i2c2_scl */
-	MV(CP(I2C2_SDA) , (PTU | IEN | M0));  /* i2c2_sda */
-	MV(CP(I2C3_SCL) , (PTU | IEN | M0));  /* i2c3_scl */
-	MV(CP(I2C3_SDA) , (PTU | IEN | M0));  /* i2c3_sda */
-	MV(CP(I2C4_SCL) , (PTU | IEN | M0));  /* i2c4_scl */
-	MV(CP(I2C4_SDA) , (PTU | IEN | M0));  /* i2c4_sda */
-	MV(CP(MCSPI1_CLK) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* mcspi1_clk */
-	MV(CP(MCSPI1_SOMI) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* mcspi1_somi */
-	MV(CP(MCSPI1_SIMO) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* mcspi1_simo */
-	MV(CP(MCSPI1_CS0) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* mcspi1_cs0 */
-	MV(CP(MCSPI1_CS1) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M3));  /* mcspi1_cs1 */
-	MV(CP(MCSPI1_CS2) , (PTU | OFF_EN | OFF_OUT_PTU | M3));  /* gpio_139 */
-	MV(CP(MCSPI1_CS3) , (PTU | IEN | M3));  /* gpio_140 */
-	MV(CP(UART3_CTS_RCTX) , (PTU | IEN | M0));  /* uart3_tx */
-	MV(CP(UART3_RTS_SD) , (M0));  /* uart3_rts_sd */
-	MV(CP(UART3_RX_IRRX) , (IEN | M0));  /* uart3_rx */
-	MV(CP(UART3_TX_IRTX) , (M0));  /* uart3_tx */
-	MV(CP(SDMMC5_CLK) , (PTU | IEN | OFF_EN | OFF_OUT_PTD | M0));  /* sdmmc5_clk */
-	MV(CP(SDMMC5_CMD) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc5_cmd */
-	MV(CP(SDMMC5_DAT0) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc5_dat0 */
-	MV(CP(SDMMC5_DAT1) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc5_dat1 */
-	MV(CP(SDMMC5_DAT2) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc5_dat2 */
-	MV(CP(SDMMC5_DAT3) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* sdmmc5_dat3 */
-	MV(CP(MCSPI4_CLK) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* mcspi4_clk */
-	MV(CP(MCSPI4_SIMO) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* mcspi4_simo */
-	MV(CP(MCSPI4_SOMI) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* mcspi4_somi */
-	MV(CP(MCSPI4_CS0) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* mcspi4_cs0 */
-	MV(CP(UART4_RX) , (IEN | M0));  /* uart4_rx */
-	MV(CP(UART4_TX) , (M0));  /* uart4_tx */
-	MV(CP(USBB2_ULPITLL_CLK) , (IEN | M3));  /* gpio_157 */
-	MV(CP(USBB2_ULPITLL_STP) , (IEN | M5));  /* dispc2_data23 */
-	MV(CP(USBB2_ULPITLL_DIR) , (IEN | M5));  /* dispc2_data22 */
-	MV(CP(USBB2_ULPITLL_NXT) , (IEN | M5));  /* dispc2_data21 */
-	MV(CP(USBB2_ULPITLL_DAT0) , (IEN | M5));  /* dispc2_data20 */
-	MV(CP(USBB2_ULPITLL_DAT1) , (IEN | M5));  /* dispc2_data19 */
-	MV(CP(USBB2_ULPITLL_DAT2) , (IEN | M5));  /* dispc2_data18 */
-	MV(CP(USBB2_ULPITLL_DAT3) , (IEN | M5));  /* dispc2_data15 */
-	MV(CP(USBB2_ULPITLL_DAT4) , (IEN | M5));  /* dispc2_data14 */
-	MV(CP(USBB2_ULPITLL_DAT5) , (IEN | M5));  /* dispc2_data13 */
-	MV(CP(USBB2_ULPITLL_DAT6) , (IEN | M5));  /* dispc2_data12 */
-	MV(CP(USBB2_ULPITLL_DAT7) , (IEN | M5));  /* dispc2_data11 */
-	MV(CP(USBB2_HSIC_DATA) , (PTD | OFF_EN | OFF_OUT_PTU | M3));  /* gpio_169 */
-	MV(CP(USBB2_HSIC_STROBE) , (PTD | OFF_EN | OFF_OUT_PTU | M3));  /* gpio_170 */
-	MV(CP(UNIPRO_TX0) , (PTD | IEN | M3));  /* gpio_171 */
-	MV(CP(UNIPRO_TY0) , (OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_col1 */
-	MV(CP(UNIPRO_TX1) , (OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_col2 */
-	MV(CP(UNIPRO_TY1) , (OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_col3 */
-	MV(CP(UNIPRO_TX2) , (PTU | IEN | M3));  /* gpio_0 */
-	MV(CP(UNIPRO_TY2) , (PTU | IEN | M3));  /* gpio_1 */
-	MV(CP(UNIPRO_RX0) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_row0 */
-	MV(CP(UNIPRO_RY0) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_row1 */
-	MV(CP(UNIPRO_RX1) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_row2 */
-	MV(CP(UNIPRO_RY1) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_row3 */
-	MV(CP(UNIPRO_RX2) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_row4 */
-	MV(CP(UNIPRO_RY2) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1));  /* kpd_row5 */
-	MV(CP(USBA0_OTG_CE) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M0));  /* usba0_otg_ce */
-	MV(CP(USBA0_OTG_DP) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* usba0_otg_dp */
-	MV(CP(USBA0_OTG_DM) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0));  /* usba0_otg_dm */
-	MV(CP(FREF_CLK1_OUT) , (M0));  /* fref_clk1_out */
-	MV(CP(FREF_CLK2_OUT) , (PTU | IEN | M3));  /* gpio_182 */
-	MV(CP(SYS_NIRQ1) , (PTU | IEN | M0));  /* sys_nirq1 */
-	MV(CP(SYS_NIRQ2) , (PTU | IEN | M0));  /* sys_nirq2 */
-	MV(CP(SYS_BOOT0) , (PTU | IEN | M3));  /* gpio_184 */
-	MV(CP(SYS_BOOT1) , (M3));  /* gpio_185 */
-	MV(CP(SYS_BOOT2) , (PTD | IEN | M3));  /* gpio_186 */
-	MV(CP(SYS_BOOT3) , (M3));  /* gpio_187 */
-	MV(CP(SYS_BOOT4) , (M3));  /* gpio_188 */
-	MV(CP(SYS_BOOT5) , (PTD | IEN | M3));  /* gpio_189 */
-	MV(CP(DPM_EMU0) , (IEN | M0));  /* dpm_emu0 */
-	MV(CP(DPM_EMU1) , (IEN | M0));  /* dpm_emu1 */
-	MV(CP(DPM_EMU2) , (IEN | M0));  /* dpm_emu2 */
-	MV(CP(DPM_EMU3) , (IEN | M5));  /* dispc2_data10 */
-	MV(CP(DPM_EMU4) , (IEN | M5));  /* dispc2_data9 */
-	MV(CP(DPM_EMU5) , (IEN | M5));  /* dispc2_data16 */
-	MV(CP(DPM_EMU6) , (IEN | M5));  /* dispc2_data17 */
-	MV(CP(DPM_EMU7) , (IEN | M5));  /* dispc2_hsync */
-	MV(CP(DPM_EMU8) , (IEN | M5));  /* dispc2_pclk */
-	MV(CP(DPM_EMU9) , (IEN | M5));  /* dispc2_vsync */
-	MV(CP(DPM_EMU10) , (IEN | M5));  /* dispc2_de */
-	MV(CP(DPM_EMU11) , (IEN | M5));  /* dispc2_data8 */
-	MV(CP(DPM_EMU12) , (IEN | M5));  /* dispc2_data7 */
-	MV(CP(DPM_EMU13) , (IEN | M5));  /* dispc2_data6 */
-	MV(CP(DPM_EMU14) , (IEN | M5));  /* dispc2_data5 */
-	MV(CP(DPM_EMU15) , (IEN | M5));  /* dispc2_data4 */
-	MV(CP(DPM_EMU16) , (M3));  /* gpio_27 */
-	MV(CP(DPM_EMU17) , (IEN | M5));  /* dispc2_data2 */
-	MV(CP(DPM_EMU18) , (IEN | M5));  /* dispc2_data1 */
-	MV(CP(DPM_EMU19) , (IEN | M5));  /* dispc2_data0 */
-	MV1(WK(PAD0_SIM_IO) , (IEN | M0));  /* sim_io */
-	MV1(WK(PAD1_SIM_CLK) , (M0));  /* sim_clk */
-	MV1(WK(PAD0_SIM_RESET) , (M0));  /* sim_reset */
-	MV1(WK(PAD1_SIM_CD) , (PTU | IEN | M0));  /* sim_cd */
-	MV1(WK(PAD0_SIM_PWRCTRL) , (M0));  /* sim_pwrctrl */
-	MV1(WK(PAD1_SR_SCL) , (PTU | IEN | M0));  /* sr_scl */
-	MV1(WK(PAD0_SR_SDA) , (PTU | IEN | M0));  /* sr_sda */
-	MV1(WK(PAD1_FREF_XTAL_IN) , (M0));  /* # */
-	MV1(WK(PAD0_FREF_SLICER_IN) , (M0));  /* fref_slicer_in */
-	MV1(WK(PAD1_FREF_CLK_IOREQ) , (M0));  /* fref_clk_ioreq */
-	MV1(WK(PAD0_FREF_CLK0_OUT) , (M2));  /* sys_drm_msecure */
-	MV1(WK(PAD1_FREF_CLK3_REQ) , (M3));  /* gpio_wk30 */
-	MV1(WK(PAD0_FREF_CLK3_OUT) , (M0));  /* fref_clk3_out */
-	MV1(WK(PAD1_FREF_CLK4_REQ) , (PTU | IEN | M0));  /* # */
-	MV1(WK(PAD0_FREF_CLK4_OUT) , (M0));  /* # */
-	MV1(WK(PAD1_SYS_32K) , (IEN | M0));  /* sys_32k */
-	MV1(WK(PAD0_SYS_NRESPWRON) , (M0));  /* sys_nrespwron */
-	MV1(WK(PAD1_SYS_NRESWARM) , (M0));  /* sys_nreswarm */
-	MV1(WK(PAD0_SYS_PWR_REQ) , (PTU | M0));  /* sys_pwr_req */
-	MV1(WK(PAD1_SYS_PWRON_RESET) , (M3));  /* gpio_wk29 */
-	MV1(WK(PAD0_SYS_BOOT6) , (IEN | M3));  /* gpio_wk9 */
-	MV1(WK(PAD1_SYS_BOOT7) , (IEN | M3));  /* gpio_wk10 */
-	MV1(WK(PAD1_FREF_CLK3_REQ),     (M3)); /* gpio_wk30 */
-	MV1(WK(PAD1_FREF_CLK4_REQ),     (M3)); /* gpio_wk7 */
-	MV1(WK(PAD0_FREF_CLK4_OUT),     (M3)); /* gpio_wk8 */ 
+void board_mux_init() {
+	MV(CP(GPMC_AD0) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* sdmmc2_dat0 */ \
+	MV(CP(GPMC_AD1) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* sdmmc2_dat1 */ \
+	MV(CP(GPMC_AD2) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* sdmmc2_dat2 */ \
+	MV(CP(GPMC_AD3) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* sdmmc2_dat3 */ \
+	MV(CP(GPMC_AD4) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* sdmmc2_dat4 */ \
+	MV(CP(GPMC_AD5) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* sdmmc2_dat5 */ \
+	MV(CP(GPMC_AD6) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* sdmmc2_dat6 */ \
+	MV(CP(GPMC_AD7) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* sdmmc2_dat7 */ \
+	MV(CP(GPMC_AD8) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M3))  /* gpio_32 */ \
+	MV(CP(GPMC_AD9) , (PTU | IEN | M3))  /* gpio_33 */ \
+	MV(CP(GPMC_AD10) , (PTU | IEN | M3))  /* gpio_34 */ \
+	MV(CP(GPMC_AD11) , (PTU | IEN | M3))  /* gpio_35 */ \
+	MV(CP(GPMC_AD12) , (PTU | IEN | M3))  /* gpio_36 */ \
+	MV(CP(GPMC_AD13) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M3))  /* gpio_37 */ \
+	MV(CP(GPMC_AD14) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M3))  /* gpio_38 */ \
+	MV(CP(GPMC_AD15) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M3))  /* gpio_39 */ \
+	MV(CP(GPMC_A16) , (M3))  /* gpio_40 */ \
+	MV(CP(GPMC_A17) , (PTD | M3))  /* gpio_41 */ \
+	MV(CP(GPMC_A18) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_row6 */ \
+	MV(CP(GPMC_A19) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_row7 */ \
+	MV(CP(GPMC_A20) , (IEN | M3))  /* gpio_44 */ \
+	MV(CP(GPMC_A21) , (M3))  /* gpio_45 */ \
+	MV(CP(GPMC_A22) , (M3))  /* gpio_46 */ \
+	MV(CP(GPMC_A23) , (OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_col7 */ \
+	MV(CP(GPMC_A24) , (PTD | M3))  /* gpio_48 */ \
+	MV(CP(GPMC_A25) , (PTD | M3))  /* gpio_49 */ \
+	MV(CP(GPMC_NCS0) , (M3))  /* gpio_50 */ \
+	MV(CP(GPMC_NCS1) , (IEN | M3))  /* gpio_51 */ \
+	MV(CP(GPMC_NCS2) , (IEN | M3))  /* gpio_52 */ \
+	MV(CP(GPMC_NCS3) , (IEN | M3))  /* gpio_53 */ \
+	MV(CP(GPMC_NWP) , (M3))  /* gpio_54 */ \
+	MV(CP(GPMC_CLK) , (PTD | M3))  /* gpio_55 */ \
+	MV(CP(GPMC_NADV_ALE) , (M3))  /* gpio_56 */ \
+	MV(CP(GPMC_NOE) , (PTU | IEN | OFF_EN | OFF_OUT_PTD | M1))  /* sdmmc2_clk */ \
+	MV(CP(GPMC_NWE) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* sdmmc2_cmd */ \
+	MV(CP(GPMC_NBE0_CLE) , (M3))  /* gpio_59 */ \
+	MV(CP(GPMC_NBE1) , (PTD | M3))  /* gpio_60 */ \
+	MV(CP(GPMC_WAIT0) , (PTU | IEN | M3))  /* gpio_61 */ \
+	MV(CP(GPMC_WAIT1) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M3))  /* gpio_62 */ \
+	MV(CP(C2C_DATA11) , (PTD | M3))  /* gpio_100 */ \
+	MV(CP(C2C_DATA12) , (PTU | IEN | M3))  /* gpio_101 */ \
+	MV(CP(C2C_DATA13) , (PTD | M3))  /* gpio_102 */ \
+	MV(CP(C2C_DATA14) , ( M1))  /* dsi2_te0 */ \
+	MV(CP(C2C_DATA15) , (PTD | M3))  /* gpio_104 */ \
+	MV(CP(HDMI_HPD) , (M0))  /* hdmi_hpd */ \
+	MV(CP(HDMI_CEC) , (M0))  /* hdmi_cec */ \
+	MV(CP(HDMI_DDC_SCL) , (PTU | M0))  /* hdmi_ddc_scl */ \
+	MV(CP(HDMI_DDC_SDA) , (PTU | IEN | M0))  /* hdmi_ddc_sda */ \
+	MV(CP(CSI21_DX0) , (IEN | M0))  /* csi21_dx0 */ \
+	MV(CP(CSI21_DY0) , (IEN | M0))  /* csi21_dy0 */ \
+	MV(CP(CSI21_DX1) , (IEN | M0))  /* csi21_dx1 */ \
+	MV(CP(CSI21_DY1) , (IEN | M0))  /* csi21_dy1 */ \
+	MV(CP(CSI21_DX2) , (IEN | M0))  /* csi21_dx2 */ \
+	MV(CP(CSI21_DY2) , (IEN | M0))  /* csi21_dy2 */ \
+	MV(CP(CSI21_DX3) , (PTD | M7))  /* csi21_dx3 */ \
+	MV(CP(CSI21_DY3) , (PTD | M7))  /* csi21_dy3 */ \
+	MV(CP(CSI21_DX4) , (PTD | OFF_EN | OFF_PD | OFF_IN | M7))  /* csi21_dx4 */ \
+	MV(CP(CSI21_DY4) , (PTD | OFF_EN | OFF_PD | OFF_IN | M7))  /* csi21_dy4 */ \
+	MV(CP(CSI22_DX0) , (IEN | M0))  /* csi22_dx0 */ \
+	MV(CP(CSI22_DY0) , (IEN | M0))  /* csi22_dy0 */ \
+	MV(CP(CSI22_DX1) , (IEN | M0))  /* csi22_dx1 */ \
+	MV(CP(CSI22_DY1) , (IEN | M0))  /* csi22_dy1 */ \
+	MV(CP(CAM_SHUTTER) , (OFF_EN | OFF_PD | OFF_OUT_PTD | M0))  /* cam_shutter */ \
+	MV(CP(CAM_STROBE) , (OFF_EN | OFF_PD | OFF_OUT_PTD | M0))  /* cam_strobe */ \
+	MV(CP(CAM_GLOBALRESET) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M3))  /* gpio_83 */ \
+	MV(CP(USBB1_ULPITLL_CLK) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M4))  /* usbb1_ulpiphy_clk */ \
+	MV(CP(USBB1_ULPITLL_STP) , (OFF_EN | OFF_OUT_PTD | M4))  /* usbb1_ulpiphy_stp */ \
+	MV(CP(USBB1_ULPITLL_DIR) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4))  /* usbb1_ulpiphy_dir */ \
+	MV(CP(USBB1_ULPITLL_NXT) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4))  /* usbb1_ulpiphy_nxt */ \
+	MV(CP(USBB1_ULPITLL_DAT0) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4))  /* usbb1_ulpiphy_dat0 */ \
+	MV(CP(USBB1_ULPITLL_DAT1) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4))  /* usbb1_ulpiphy_dat1 */ \
+	MV(CP(USBB1_ULPITLL_DAT2) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4))  /* usbb1_ulpiphy_dat2 */ \
+	MV(CP(USBB1_ULPITLL_DAT3) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4))  /* usbb1_ulpiphy_dat3 */ \
+	MV(CP(USBB1_ULPITLL_DAT4) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4))  /* usbb1_ulpiphy_dat4 */ \
+	MV(CP(USBB1_ULPITLL_DAT5) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4))  /* usbb1_ulpiphy_dat5 */ \
+	MV(CP(USBB1_ULPITLL_DAT6) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4))  /* usbb1_ulpiphy_dat6 */ \
+	MV(CP(USBB1_ULPITLL_DAT7) , (IEN | OFF_EN | OFF_PD | OFF_IN | M4))  /* usbb1_ulpiphy_dat7 */ \
+	MV(CP(USBB1_HSIC_DATA) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* usbb1_hsic_data */ \
+	MV(CP(USBB1_HSIC_STROBE) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* usbb1_hsic_strobe */ \
+	MV(CP(USBC1_ICUSB_DP) , (IEN | M0))  /* usbc1_icusb_dp */ \
+	MV(CP(USBC1_ICUSB_DM) , (IEN | M0))  /* usbc1_icusb_dm */ \
+	MV(CP(SDMMC1_CLK) , (PTU | OFF_EN | OFF_OUT_PTD | M0))  /* sdmmc1_clk */ \
+	MV(CP(SDMMC1_CMD) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc1_cmd */ \
+	MV(CP(SDMMC1_DAT0) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc1_dat0 */ \
+	MV(CP(SDMMC1_DAT1) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc1_dat1 */ \
+	MV(CP(SDMMC1_DAT2) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc1_dat2 */ \
+	MV(CP(SDMMC1_DAT3) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc1_dat3 */ \
+	MV(CP(SDMMC1_DAT4) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc1_dat4 */ \
+	MV(CP(SDMMC1_DAT5) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc1_dat5 */ \
+	MV(CP(SDMMC1_DAT6) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc1_dat6 */ \
+	MV(CP(SDMMC1_DAT7) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc1_dat7 */ \
+	MV(CP(ABE_MCBSP2_CLKX) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* abe_mcbsp2_clkx */ \
+	MV(CP(ABE_MCBSP2_DR) , (IEN | OFF_EN | OFF_OUT_PTD | M0))  /* abe_mcbsp2_dr */ \
+	MV(CP(ABE_MCBSP2_DX) , (OFF_EN | OFF_OUT_PTD | M0))  /* abe_mcbsp2_dx */ \
+	MV(CP(ABE_MCBSP2_FSX) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* abe_mcbsp2_fsx */ \
+	MV(CP(ABE_MCBSP1_CLKX) , ( IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* abe_mcbsp1_clock */ \
+	MV(CP(ABE_MCBSP1_DR) , ( IEN | OFF_EN | OFF_OUT_PTD | M0))  /* abe_mcbsp1_dx */ \
+	MV(CP(ABE_MCBSP1_DX) , (OFF_EN | OFF_OUT_PTD | M0))  /* abe_mcbsp1_dx */ \
+	MV(CP(ABE_MCBSP1_FSX) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* abe_mcbsp1_fsx */ \
+	MV(CP(ABE_PDM_UL_DATA) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* abe_pdm_ul_data */ \
+	MV(CP(ABE_PDM_DL_DATA) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* abe_pdm_dl_data */ \
+	MV(CP(ABE_PDM_FRAME) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* abe_pdm_frame */ \
+	MV(CP(ABE_PDM_LB_CLK) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* abe_pdm_lb_clk */ \
+	MV(CP(ABE_CLKS) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* abe_clks */ \
+	MV(CP(ABE_DMIC_CLK1) , (M0))  /* abe_dmic_clk1 */ \
+	MV(CP(ABE_DMIC_DIN1) , (IEN | M0))  /* abe_dmic_din1 */ \
+	MV(CP(ABE_DMIC_DIN2) , (PTU | IEN | M3))  /* gpio_121 */ \
+	MV(CP(ABE_DMIC_DIN3) , (IEN | M0))  /* abe_dmic_din3 */ \
+	MV(CP(UART2_CTS) , (PTU | IEN | M0))  /* uart2_cts */ \
+	MV(CP(UART2_RTS) , (M0))  /* uart2_rts */ \
+	MV(CP(UART2_RX) , (PTU | IEN | M0))  /* uart2_rx */ \
+	MV(CP(UART2_TX) , (M0))  /* uart2_tx */ \
+	MV(CP(HDQ_SIO) , (M3))  /* gpio_127 */ \
+	MV(CP(I2C1_SCL) , (PTU | IEN | M0))  /* i2c1_scl */ \
+	MV(CP(I2C1_SDA) , (PTU | IEN | M0))  /* i2c1_sda */ \
+	MV(CP(I2C2_SCL) , (PTU | IEN | M0))  /* i2c2_scl */ \
+	MV(CP(I2C2_SDA) , (PTU | IEN | M0))  /* i2c2_sda */ \
+	MV(CP(I2C3_SCL) , (PTU | IEN | M0))  /* i2c3_scl */ \
+	MV(CP(I2C3_SDA) , (PTU | IEN | M0))  /* i2c3_sda */ \
+	MV(CP(I2C4_SCL) , (PTU | IEN | M0))  /* i2c4_scl */ \
+	MV(CP(I2C4_SDA) , (PTU | IEN | M0))  /* i2c4_sda */ \
+	MV(CP(MCSPI1_CLK) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* mcspi1_clk */ \
+	MV(CP(MCSPI1_SOMI) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* mcspi1_somi */ \
+	MV(CP(MCSPI1_SIMO) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* mcspi1_simo */ \
+	MV(CP(MCSPI1_CS0) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* mcspi1_cs0 */ \
+	MV(CP(MCSPI1_CS1) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M3))  /* mcspi1_cs1 */ \
+	MV(CP(MCSPI1_CS2) , (PTU | OFF_EN | OFF_OUT_PTU | M3))  /* gpio_139 */ \
+	MV(CP(MCSPI1_CS3) , (PTU | IEN | M3))  /* gpio_140 */ \
+	MV(CP(UART3_CTS_RCTX) , (PTU | IEN | M0))  /* uart3_tx */ \
+	MV(CP(UART3_RTS_SD) , (M0))  /* uart3_rts_sd */ \
+	MV(CP(UART3_RX_IRRX) , (IEN | M0))  /* uart3_rx */ \
+	MV(CP(UART3_TX_IRTX) , (M0))  /* uart3_tx */ \
+	MV(CP(SDMMC5_CLK) , (PTU | IEN | OFF_EN | OFF_OUT_PTD | M0))  /* sdmmc5_clk */ \
+	MV(CP(SDMMC5_CMD) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc5_cmd */ \
+	MV(CP(SDMMC5_DAT0) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc5_dat0 */ \
+	MV(CP(SDMMC5_DAT1) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc5_dat1 */ \
+	MV(CP(SDMMC5_DAT2) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc5_dat2 */ \
+	MV(CP(SDMMC5_DAT3) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* sdmmc5_dat3 */ \
+	MV(CP(MCSPI4_CLK) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* mcspi4_clk */ \
+	MV(CP(MCSPI4_SIMO) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* mcspi4_simo */ \
+	MV(CP(MCSPI4_SOMI) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* mcspi4_somi */ \
+	MV(CP(MCSPI4_CS0) , (PTD | IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* mcspi4_cs0 */ \
+	MV(CP(UART4_RX) , (IEN | M0))  /* uart4_rx */ \
+	MV(CP(UART4_TX) , (M0))  /* uart4_tx */ \
+	MV(CP(USBB2_ULPITLL_CLK) , (IEN | M3))  /* gpio_157 */ \
+	MV(CP(USBB2_ULPITLL_STP) , (IEN | M5))  /* dispc2_data23 */ \
+	MV(CP(USBB2_ULPITLL_DIR) , (IEN | M5))  /* dispc2_data22 */ \
+	MV(CP(USBB2_ULPITLL_NXT) , (IEN | M5))  /* dispc2_data21 */ \
+	MV(CP(USBB2_ULPITLL_DAT0) , (IEN | M5))  /* dispc2_data20 */ \
+	MV(CP(USBB2_ULPITLL_DAT1) , (IEN | M5))  /* dispc2_data19 */ \
+	MV(CP(USBB2_ULPITLL_DAT2) , (IEN | M5))  /* dispc2_data18 */ \
+	MV(CP(USBB2_ULPITLL_DAT3) , (IEN | M5))  /* dispc2_data15 */ \
+	MV(CP(USBB2_ULPITLL_DAT4) , (IEN | M5))  /* dispc2_data14 */ \
+	MV(CP(USBB2_ULPITLL_DAT5) , (IEN | M5))  /* dispc2_data13 */ \
+	MV(CP(USBB2_ULPITLL_DAT6) , (IEN | M5))  /* dispc2_data12 */ \
+	MV(CP(USBB2_ULPITLL_DAT7) , (IEN | M5))  /* dispc2_data11 */ \
+	MV(CP(USBB2_HSIC_DATA) , (PTD | OFF_EN | OFF_OUT_PTU | M3))  /* gpio_169 */ \
+	MV(CP(USBB2_HSIC_STROBE) , (PTD | OFF_EN | OFF_OUT_PTU | M3))  /* gpio_170 */ \
+	MV(CP(UNIPRO_TX0) , (PTD | IEN | M3))  /* gpio_171 */ \
+	MV(CP(UNIPRO_TY0) , (OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_col1 */ \
+	MV(CP(UNIPRO_TX1) , (OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_col2 */ \
+	MV(CP(UNIPRO_TY1) , (OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_col3 */ \
+	MV(CP(UNIPRO_TX2) , (PTU | IEN | M3))  /* gpio_0 */ \
+	MV(CP(UNIPRO_TY2) , (PTU | IEN | M3))  /* gpio_1 */ \
+	MV(CP(UNIPRO_RX0) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_row0 */ \
+	MV(CP(UNIPRO_RY0) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_row1 */ \
+	MV(CP(UNIPRO_RX1) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_row2 */ \
+	MV(CP(UNIPRO_RY1) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_row3 */ \
+	MV(CP(UNIPRO_RX2) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_row4 */ \
+	MV(CP(UNIPRO_RY2) , (PTU | IEN | OFF_EN | OFF_PD | OFF_IN | M1))  /* kpd_row5 */ \
+	MV(CP(USBA0_OTG_CE) , (PTD | OFF_EN | OFF_PD | OFF_OUT_PTD | M0))  /* usba0_otg_ce */ \
+	MV(CP(USBA0_OTG_DP) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* usba0_otg_dp */ \
+	MV(CP(USBA0_OTG_DM) , (IEN | OFF_EN | OFF_PD | OFF_IN | M0))  /* usba0_otg_dm */ \
+	MV(CP(FREF_CLK1_OUT) , (M0))  /* fref_clk1_out */ \
+	MV(CP(FREF_CLK2_OUT) , (PTU | IEN | M3))  /* gpio_182 */ \
+	MV(CP(SYS_NIRQ1) , (PTU | IEN | M0))  /* sys_nirq1 */ \
+	MV(CP(SYS_NIRQ2) , (PTU | IEN | M0))  /* sys_nirq2 */ \
+	MV(CP(SYS_BOOT0) , (PTU | IEN | M3))  /* gpio_184 */ \
+	MV(CP(SYS_BOOT1) , (M3))  /* gpio_185 */ \
+	MV(CP(SYS_BOOT2) , (PTD | IEN | M3))  /* gpio_186 */ \
+	MV(CP(SYS_BOOT3) , (M3))  /* gpio_187 */ \
+	MV(CP(SYS_BOOT4) , (M3))  /* gpio_188 */ \
+	MV(CP(SYS_BOOT5) , (PTD | IEN | M3))  /* gpio_189 */ \
+	MV(CP(DPM_EMU0) , (IEN | M0))  /* dpm_emu0 */ \
+	MV(CP(DPM_EMU1) , (IEN | M0))  /* dpm_emu1 */ \
+	MV(CP(DPM_EMU2) , (IEN | M0))  /* dpm_emu2 */ \
+	MV(CP(DPM_EMU3) , (IEN | M5))  /* dispc2_data10 */ \
+	MV(CP(DPM_EMU4) , (IEN | M5))  /* dispc2_data9 */ \
+	MV(CP(DPM_EMU5) , (IEN | M5))  /* dispc2_data16 */ \
+	MV(CP(DPM_EMU6) , (IEN | M5))  /* dispc2_data17 */ \
+	MV(CP(DPM_EMU7) , (IEN | M5))  /* dispc2_hsync */ \
+	MV(CP(DPM_EMU8) , (IEN | M5))  /* dispc2_pclk */ \
+	MV(CP(DPM_EMU9) , (IEN | M5))  /* dispc2_vsync */ \
+	MV(CP(DPM_EMU10) , (IEN | M5))  /* dispc2_de */ \
+	MV(CP(DPM_EMU11) , (IEN | M5))  /* dispc2_data8 */ \
+	MV(CP(DPM_EMU12) , (IEN | M5))  /* dispc2_data7 */ \
+	MV(CP(DPM_EMU13) , (IEN | M5))  /* dispc2_data6 */ \
+	MV(CP(DPM_EMU14) , (IEN | M5))  /* dispc2_data5 */ \
+	MV(CP(DPM_EMU15) , (IEN | M5))  /* dispc2_data4 */ \
+	MV(CP(DPM_EMU16) , (M3))  /* gpio_27 */ \
+	MV(CP(DPM_EMU17) , (IEN | M5))  /* dispc2_data2 */ \
+	MV(CP(DPM_EMU18) , (IEN | M5))  /* dispc2_data1 */ \
+	MV(CP(DPM_EMU19) , (IEN | M5))  /* dispc2_data0 */ \
+	MV1(WK(PAD0_SIM_IO) , (IEN | M0))  /* sim_io */ \
+	MV1(WK(PAD1_SIM_CLK) , (M0))  /* sim_clk */ \
+	MV1(WK(PAD0_SIM_RESET) , (M0))  /* sim_reset */ \
+	MV1(WK(PAD1_SIM_CD) , (PTU | IEN | M0))  /* sim_cd */ \
+	MV1(WK(PAD0_SIM_PWRCTRL) , (M0))  /* sim_pwrctrl */ \
+	MV1(WK(PAD1_SR_SCL) , (PTU | IEN | M0))  /* sr_scl */ \
+	MV1(WK(PAD0_SR_SDA) , (PTU | IEN | M0))  /* sr_sda */ \
+	MV1(WK(PAD1_FREF_XTAL_IN) , (M0))  /* # */ \
+	MV1(WK(PAD0_FREF_SLICER_IN) , (M0))  /* fref_slicer_in */ \
+	MV1(WK(PAD1_FREF_CLK_IOREQ) , (M0))  /* fref_clk_ioreq */ \
+	MV1(WK(PAD0_FREF_CLK0_OUT) , (M2))  /* sys_drm_msecure */ \
+	MV1(WK(PAD1_FREF_CLK3_REQ) , (M3))  /* gpio_wk30 */ \
+	MV1(WK(PAD0_FREF_CLK3_OUT) , (M0))  /* fref_clk3_out */ \
+	MV1(WK(PAD1_FREF_CLK4_REQ) , (PTU | IEN | M0))  /* # */ \
+	MV1(WK(PAD0_FREF_CLK4_OUT) , (M0))  /* # */ \
+	MV1(WK(PAD1_SYS_32K) , (IEN | M0))  /* sys_32k */ \
+	MV1(WK(PAD0_SYS_NRESPWRON) , (M0))  /* sys_nrespwron */ \
+	MV1(WK(PAD1_SYS_NRESWARM) , (M0))  /* sys_nreswarm */ \
+	MV1(WK(PAD0_SYS_PWR_REQ) , (PTU | M0))  /* sys_pwr_req */ \
+	MV1(WK(PAD1_SYS_PWRON_RESET) , (M3))  /* gpio_wk29 */ \
+	MV1(WK(PAD0_SYS_BOOT6) , (IEN | M3))  /* gpio_wk9 */ \
+	MV1(WK(PAD1_SYS_BOOT7) , (IEN | M3))  /* gpio_wk10 */ \
+	MV1(WK(PAD1_FREF_CLK3_REQ),     (M3)) /* gpio_wk30 */ \
+	MV1(WK(PAD1_FREF_CLK4_REQ),     (M3)) /* gpio_wk7 */ \
+	MV1(WK(PAD0_FREF_CLK4_OUT),     (M3)) /* gpio_wk8 */ 
 }
 
-
-const struct ddr_regs elpida2G_400mhz_2cs = {
-	/* tRRD changed from 10ns to 12.5ns because of the tFAW requirement*/
-	.tim1		= 0x10eb0662,
+/* Timing regs for Elpida */
+const struct ddr_regs ddr_regs_elpida2G_400_mhz = {
+	.tim1		= 0x10eb065a,
 	.tim2		= 0x20370dd2,
 	.tim3		= 0x00b1c33f,
 	.phy_ctrl_1	= 0x849FF408,
 	.ref_ctrl	= 0x00000618,
-	.config_init	= 0x80000eb9,
-	.config_final	= 0x80001ab9,
-	.zq_config	= 0xD00b3215,
+	.config_init	= 0x80000eb1,
+	.config_final	= 0x80001ab1,
+	.zq_config	= 0x500b3215,
 	.mr1		= 0x83,
 	.mr2		= 0x4
 };
 
+/*
+ * 400 MHz + 2 CS = 1 GB
+ */
+const struct ddr_regs ddr_regs_elpida2G_400_mhz_2cs = {
+	/* tRRD changed from 10ns to 12.5ns because of the tFAW requirement*/
+	.tim1		= 0x10eb0662,
+	.tim2		= 0x20370dd2,
+	.tim3		= 0x00b1c33f,
+#ifdef CONFIG_OMAP4460
+	.phy_ctrl_1	= 0x449FF408,
+#else
+	.phy_ctrl_1	= 0x849FF408,
+#endif
+	.ref_ctrl	= 0x00000618,
+#ifdef CONFIG_OMAP4460
+	.config_init	= 0x80800eb9,
+	.config_final	= 0x80801ab9,
+#else
+	.config_init	= 0x80000eb9,
+	.config_final	= 0x80001ab9,
+#endif
+	.zq_config	= 0xd00b3215,
+	.mr1		= 0x83,
+	.mr2		= 0x4
+};
+const struct ddr_regs ddr_regs_elpida2G_380_mhz = {
+	.tim1		= 0x10cb061a,
+	.tim2		= 0x20350d52,
+	.tim3		= 0x00b1431f,
+	.phy_ctrl_1	= 0x849FF408,
+	.ref_ctrl	= 0x000005ca,
+	.config_init	= 0x80000eb1,
+	.config_final	= 0x80001ab1,
+	.zq_config	= 0x500b3215,
+	.mr1		= 0x83,
+	.mr2		= 0x4
+};
 
+const struct ddr_regs ddr_regs_elpida2G_200_mhz = {
+	.tim1		= 0x08648309,
+	.tim2		= 0x101b06ca,
+	.tim3		= 0x0048a19f,
+	.phy_ctrl_1	= 0x849FF405,
+	.ref_ctrl	= 0x0000030c,
+	.config_init	= 0x80000eb1,
+	.config_final	= 0x80000eb1,
+	.zq_config	= 0x500b3215,
+	.mr1		= 0x23,
+	.mr2		= 0x1
+};
+
+const struct ddr_regs ddr_regs_elpida2G_200_mhz_2cs = {
+	.tim1		= 0x08648309,
+	.tim2		= 0x101b06ca,
+	.tim3		= 0x0048a19f,
+	.phy_ctrl_1	= 0x849FF405,
+	.ref_ctrl	= 0x0000030c,
+	.config_init	= 0x80000eb9,
+	.config_final	= 0x80000eb9,
+	.zq_config	= 0xD00b3215,
+	.mr1		= 0x23,
+	.mr2		= 0x1
+};
+
+/* ddr_init() - initializes ddr */
 void board_ddr_init(void)
 {
-	/* 1GB, 128B interleaved */
-	writel(0x80640300, DMM_BASE + DMM_LISA_MAP_0);
-	writel(0x00000000, DMM_BASE + DMM_LISA_MAP_2);
-	writel(0xFF020100, DMM_BASE + DMM_LISA_MAP_3);
+	u32 rev;
+	const struct ddr_regs *ddr_regs = 0;
+	rev = get_omap_rev();
+	if (rev == OMAP4430_ES1_0)
+		ddr_regs = &ddr_regs_elpida2G_380_mhz;
+	else if (rev == OMAP4430_ES2_0)
+		ddr_regs = &ddr_regs_elpida2G_200_mhz_2cs;
+	else if (rev >= OMAP4430_ES2_1)
+		ddr_regs = &ddr_regs_elpida2G_400_mhz_2cs;
+	/*
+	 * DMM Configuration:
+	 * ES1.0 - 512 MB
+	 * ES2.0 - 1GB
+	 * 128 byte interleaved
+	 */
+	if (rev == OMAP4430_ES1_0)
+		writel(0x80540300, DMM_BASE + DMM_LISA_MAP_0);
+	else if (rev >= OMAP4460_ES1_0) {
+		writel(0x80640300, DMM_BASE + DMM_LISA_MAP_0);
+		writel(0x80640300, MA_BASE + DMM_LISA_MAP_0);
+	} else
+		writel(0x80640300, DMM_BASE + DMM_LISA_MAP_0);
 
-	omap4_ddr_init(&elpida2G_400mhz_2cs,
-		       &elpida2G_400mhz_2cs);
+	/* same memory part on both EMIFs */
+	omap4_ddr_init(ddr_regs, ddr_regs);
 }

--- a/boot.c
+++ b/boot.c
@@ -43,7 +43,7 @@ int boot_image(unsigned machtype, unsigned image, unsigned len)
 
 	if (n != 8) {
 		printf("jumping to 0x%x...\n", CONFIG_ADDR_DOWNLOAD);
-		entry = CONFIG_ADDR_DOWNLOAD;
+		entry = (void (*)(unsigned, unsigned, unsigned))CONFIG_ADDR_DOWNLOAD;
 		entry(0, cfg_machine_type, CONFIG_ADDR_ATAGS);
 		for (;;);
 	}

--- a/include/aboot/aboot.h
+++ b/include/aboot/aboot.h
@@ -70,16 +70,31 @@ extern void configure_core_dpll_no_lock(void);
 extern void lock_core_dpll_shadow(void);
 
 /* rev-id stuff */
-typedef enum {
-	OMAP_REV_INVALID,
-	OMAP_4430_ES1_DOT_0,
-	OMAP_4430_ES2_DOT_0,
-	OMAP_4430_ES2_DOT_1,
-	OMAP_4430_ES2_DOT_2,
-	OMAP_4430_ES2_DOT_3,
-	OMAP_4460_ES1_DOT_0
-}omap_rev;
+/* Cortex-A9 revisions */
+#define MIDR_CORTEX_A9_R0P1     0x410FC091
+#define MIDR_CORTEX_A9_R1P2     0x411FC092
+#define MIDR_CORTEX_A9_R1P3     0x411FC093
+/* TODO: change during wakeup */
+#define MIDR_CORTEX_A9_R2P10    0x412FC09A
 
-extern omap_rev get_omap_rev(void);
+/* 4430 Silicon revisions */
+#define OMAP4_CONTROL_ID_CODE_ES1_0     0x0B85202F
+#define OMAP4_CONTROL_ID_CODE_ES2_0     0x1B85202F
+#define OMAP4_CONTROL_ID_CODE_ES2_1     0x3B95C02F
+#define OMAP4_CONTROL_ID_CODE_ES2_2     0x4B95C02F
+#define OMAP4_CONTROL_ID_CODE_ES2_3     0x6B95C02F
+
+/* 4460 Silicon revisions */
+#define OMAP4_CONTROL_ID_CODE_4460_ES1  0x0B94E02F
+
+#define OMAP4430_SILICON_ID_INVALID     0
+#define OMAP4430_ES1_0  1
+#define OMAP4430_ES2_0  2
+#define OMAP4430_ES2_1  3
+#define OMAP4430_ES2_2  4
+#define OMAP4430_ES2_3  6
+#define OMAP4460_ES1_0 10
+
+extern int get_omap_rev(void);
 
 #endif

--- a/include/aboot/aboot.h
+++ b/include/aboot/aboot.h
@@ -96,5 +96,6 @@ extern void lock_core_dpll_shadow(void);
 #define OMAP4460_ES1_0 10
 
 extern int get_omap_rev(void);
+extern u32 omap4_silicon_type(void);
 
 #endif

--- a/include/omap4/bits.h
+++ b/include/omap4/bits.h
@@ -1,0 +1,48 @@
+/* bits.h
+ * Copyright (c) 2004-2009 Texas Instruments
+ *
+ * This package is free software;  you can redistribute it and/or
+ * modify it under the terms of the license found in the file
+ * named COPYING that should have accompanied this file.
+ *
+ * THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef __bits_h
+#define __bits_h 1
+
+#define BIT0  (1<<0)
+#define BIT1  (1<<1)
+#define BIT2  (1<<2)
+#define BIT3  (1<<3)
+#define BIT4  (1<<4)
+#define BIT5  (1<<5)
+#define BIT6  (1<<6)
+#define BIT7  (1<<7)
+#define BIT8  (1<<8)
+#define BIT9  (1<<9)
+#define BIT10 (1<<10)
+#define BIT11 (1<<11)
+#define BIT12 (1<<12)
+#define BIT13 (1<<13)
+#define BIT14 (1<<14)
+#define BIT15 (1<<15)
+#define BIT16 (1<<16)
+#define BIT17 (1<<17)
+#define BIT18 (1<<18)
+#define BIT19 (1<<19)
+#define BIT20 (1<<20)
+#define BIT21 (1<<21)
+#define BIT22 (1<<22)
+#define BIT23 (1<<23)
+#define BIT24 (1<<24)
+#define BIT25 (1<<25)
+#define BIT26 (1<<26)
+#define BIT27 (1<<27)
+#define BIT28 (1<<28)
+#define BIT29 (1<<29)
+#define BIT30 (1<<30)
+#define BIT31 (1<<31)
+
+#endif

--- a/include/omap4/clocks.h
+++ b/include/omap4/clocks.h
@@ -1,0 +1,51 @@
+/*
+ * clocks.h
+ *
+ * Copyright(c) 2010 Texas Instruments.   All rights reserved.
+ *
+ * Texas Instruments, <www.ti.com>
+ * Richard Woodruff <r-woodruff2@ti.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  * Neither the name Texas Instruments nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _OMAP44XX_CLOCKS_H_
+#define _OMAP44XX_CLOCKS_H_
+
+#define LDELAY      12000000
+
+#define S12M		12000000
+#define S13M		13000000
+#define S16_8M		16800000
+#define S19_2M		19200000
+#define S24M		24000000
+#define S26M		26000000
+#define	S27M		27000000
+#define S38_4M		38400000
+
+#include <omap4/clocks443x.h>
+
+#endif

--- a/include/omap4/clocks443x.h
+++ b/include/omap4/clocks443x.h
@@ -1,0 +1,171 @@
+/*
+ * clocks443x.h
+ *
+ * Copyright(c) 2010 Texas Instruments.   All rights reserved.
+ * Texas Instruments, <www.ti.com>
+ * Richard Woodruff <r-woodruff2@ti.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  * Neither the name Texas Instruments nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _OMAP443X_CLOCKS_H_
+#define _OMAP443X_CLOCKS_H_
+
+#define PLL_STOP        1         /* PER & IVA */
+#define PLL_MN_POWER_BYPASS 	4
+#define PLL_LOW_POWER_BYPASS   5  /* MPU, IVA & CORE */
+#define PLL_FAST_RELOCK_BYPASS 6  /* CORE */
+#define PLL_LOCK        7         /* MPU, IVA, CORE & PER */
+
+/* CM_IDLEST_DPLL fields */
+#define ST_DPLL_CLK_MASK                1
+
+/* The following configurations are OPP and SysClk value independant
+ * and hence are defined here. All the other DPLL related values are
+ * tabulated in lowlevel_init.S.
+ */
+
+/* CORE DPLL */
+#  define CORE_M3X2      2        /* 332MHz : CM_CLKSEL1_EMU */
+#  define CORE_SSI_DIV   3        /* 221MHz : CM_CLKSEL_CORE */
+#  define CORE_FUSB_DIV  2        /* 41.5MHz: */
+#  define CORE_L4_DIV    2        /*  83MHz : L4 */
+#  define CORE_L3_DIV    2        /* 166MHz : L3 {DDR} */
+#  define GFX_DIV        2        /*  83MHz : CM_CLKSEL_GFX */
+#  define WKUP_RSM       2        /* 41.5MHz: CM_CLKSEL_WKUP */
+
+/* PER DPLL */
+# define PER_M6X2       3         /* 288MHz: CM_CLKSEL1_EMU */
+# define PER_M5X2       4         /* 216MHz: CM_CLKSEL_CAM */
+# define PER_M4X2       9         /* 96MHz : CM_CLKSEL_DSS-dss1 */
+# define PER_M3X2       16        /* 54MHz : CM_CLKSEL_DSS-tv */
+
+#  define CLSEL1_EMU_VAL ((CORE_M3X2 << 16) | (PER_M6X2 << 24) | (0x0a50))
+
+#ifdef PRCM_CLK_CFG2_332MHZ
+# define M_12		0xA6
+# define N_12		0x05
+# define FSEL_12	0x07
+# define M2_12		0x01 /* M3 of 2 */
+
+# define M_12_ES1	0x0E
+# define FSL_12_ES1 0x03
+# define M2_12_ES1  0x1 /* M3 of 2 */
+
+# define M_13       0x14C
+# define N_13       0x0C
+# define FSEL_13	0x03
+# define M2_13		0x01 /* M3 of 2 */
+
+# define M_13_ES1	0x1B2
+# define N_13_ES1	0x10
+# define FSL_13_ES1 0x03
+# define M2_13_ES1	0x01 /* M3 of 2 */
+
+# define M_19p2     0x19F
+# define N_19p2     0x17
+# define FSEL_19p2  0x03
+# define M2_19p2    0x01 /* M3 of 2 */
+
+# define M_19p2_ES1	0x19F
+# define N_19p2_ES1	0x17
+# define FSL_19p2_ES1 0x03
+# define M2_19p2_ES1 0x01 /* M3 of 2 */
+
+# define M_26       0xA6
+# define N_26       0x0C
+# define FSEL_26    0x07
+# define M2_26      0x01 /* M3 of 2 */
+
+# define M_26_ES1	0x1B2
+# define N_26_ES1	0x21
+# define FSL_26_ES1	0x03
+# define M2_26_ES1	0x01 /* M3 of 2 */
+
+# define M_38p4     0x19F
+# define N_38p4     0x2F
+# define FSEL_38p4  0x03
+# define M2_38p4    0x01 /* M3 of 2 */
+
+# define M_38p4_ES1	0x19F
+# define N_38p4_ES1	0x2F
+# define FSL_38p4_ES1 0x03
+# define M2_38p4_ES1 0x01 /* M3 of 2 */
+
+#elif defined(PRCM_CLK_CFG2_266MHZ)
+# define M_12		0x85
+# define N_12       0x05
+# define FSEL_12    0x07
+# define M2_12      0x02 /* M3 of 2 */
+
+# define M_12_ES1	0x85  /* 0x10A */
+# define N_12_ES1	0x05  /* 0x05 */
+# define FSL_12_ES1 0x07  /* 0x7 */
+# define M2_12_ES1  0x2   /* 0x2 with an M3 of 4*/
+
+# define M_13       0x10A
+# define N_13       0x0C
+# define FSEL_13    0x3
+# define M2_13      0x1 /* M3 of 2 */
+
+# define M_13_ES1	0x10A /* 0x214 */
+# define N_13_ES1	0x0C  /* 0xC */
+# define FSL_13_ES1 0x3   /* 0x3 */
+# define M2_13_ES1	0x1   /* 0x2 with an M3 of 4*/
+
+# define M_19p2     0x115
+# define N_19p2     0x13
+# define FSEL_19p2  0x03
+# define M2_19p2    0x01 /* M3 of 2 */
+
+# define M_19p2_ES1	0x115  /* 0x299 */
+# define N_19p2_ES1	0x13   /* 0x17 */
+# define FSL_19p2_ES1 0x03 /* 0x03 */
+# define M2_19p2_ES1 0x01  /* 0x2 with M3 of 4 */
+
+# define M_26		0x85
+# define N_26		0x0C
+# define FSEL_26	0x07
+# define M2_26		0x01 /* M3 of 2 */
+
+# define M_26_ES1	0x85  /* 0x10A */
+# define N_26_ES1	0x0C  /* 0xC */
+# define FSL_26_ES1 0x07  /* 0x7 */
+# define M2_26_ES1	0x01  /* 0x2 with an M3 of 4 */
+
+# define M_38p4     0x11C
+# define N_38p4     0x28
+# define FSEL_38p4  0x03
+# define M2_38p4    0x01 /* M3 of 2 */
+
+# define M_38p4_ES1	0x11C  /* 0x299 */
+# define N_38p4_ES1	0x28   /* 0x2f */
+# define FSL_38p4_ES1 0x03 /* 0x3 */
+# define M2_38p4_ES1 0x01  /* 0x2 with an M3 of 4*/
+
+#endif
+
+#endif  /* endif _OMAP443X_CLOCKS_H_ */

--- a/include/omap4/hw.h
+++ b/include/omap4/hw.h
@@ -521,6 +521,8 @@
 #define EMIF1_BASE			0x4c000000
 #define EMIF2_BASE			0x4d000000
 #define DMM_BASE			0x4e000000
+#define MA_BASE                         0x482af000
+
 /* EMIF */
 #define EMIF_MOD_ID_REV			0x0000
 #define EMIF_STATUS			0x0004

--- a/include/omap4/hw.h
+++ b/include/omap4/hw.h
@@ -69,6 +69,15 @@
 /* TAP information  dont know for 3430*/
 #define OMAP44XX_TAP_BASE	(0x49000000) /*giving some junk for virtio */
 
+/* STD_FUSE_PROD_ID_1 */
+#define STD_FUSE_PROD_ID_1		(OMAP44XX_CTRL_GEN_BASE + 0x218)
+#define PROD_ID_1_SILICON_TYPE_SHIFT	16
+#define PROD_ID_1_SILICON_TYPE_MASK	(3 << 16)
+
+#define PROD_ID_1_SILICON_TYPE_LOW_PERF		0
+#define PROD_ID_1_SILICON_TYPE_STD_PERF		1
+#define PROD_ID_1_SILICON_TYPE_HIGH_PERF	2
+
 /* UART */
 #define OMAP44XX_UART1			(OMAP44XX_L4_PER+0x6a000)
 #define OMAP44XX_UART2			(OMAP44XX_L4_PER+0x6c000)
@@ -283,6 +292,7 @@
 #define CM_DIV_M5_DPLL_DDRPHY			0x4a00423c
 #define CM_DIV_M6_DPLL_DDRPHY			0x4a004240
 #define CM_SSC_DELTAMSTEP_DPLL_DDRPHY		0x4a004248
+#define CM_MPU_MPU_CLKCTRL			0x4a004320
 
 /* CM1.ABE register offsets */
 #define CM1_ABE_CLKSTCTRL		0x4a004500
@@ -470,6 +480,9 @@
 #define CM_DSS_DSS_CLKCTRL              0x4a009120
 #define CM_DSS_DEISS_CLKCTRL            0x4a009128
 
+/* PM.DSS */
+#define PM_DSS_PWRSTCTRL		0x4a307100
+
 /* CM2.SGX */
 #define CM_SGX_CLKSTCTRL                0x4a009200
 #define CM_SGX_SGX_CLKCTRL              0x4a009220
@@ -589,6 +602,7 @@ struct dpll_param {
 	unsigned int m5;
 	unsigned int m6;
 	unsigned int m7;
+	unsigned int sd_div;
 };
 
 void omap4_ddr_init(const struct ddr_regs *ddr1,

--- a/tools/usbboot.c
+++ b/tools/usbboot.c
@@ -52,10 +52,7 @@ int usb_boot(usb_handle *usb,
 	     void *data2, unsigned sz2)
 {
 	uint32_t msg_boot = 0xF0030002;
-    uint32_t msg_getid = 0xF0030003;
 	uint32_t msg_size = sz;
-    uint8_t id[81];
-    int i;
 
 #if 0
     memset(data, 0xee, 81);


### PR DESCRIPTION
These patches should be applied as it corrects the detection of the silicon version, and clocks the DDR at the correct speed for the early adopter boards.
