### PR TITLE
Add delay before reading 2nd stage response to prevent stuck on some systems

### DIFF
--- a/tools/usbboot.c
+++ b/tools/usbboot.c
@@ -83,6 +83,7 @@ int usb_boot(usb_handle *usb,
 	usb_write(usb, data, sz);
 
 	if (data2) {
+		usleep(2000000);
 		fprintf(stderr,"waiting for 2ndstage response...\n");
 		usb_read(usb, &msg_size, sizeof(msg_size));
 		if (msg_size != 0xaabbccdd) {


### PR DESCRIPTION
...lay, I just can't get my system (MacBookPro3,1 + Mac OSX 10.7.4 + Parallels Desktop 7.0.15095 + Ubuntu 10.04.4 LTS + Panda Board ES REV B1) entering fastboot mode.
