### PR TITLE
Repair this program for 2015.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ what_to_build:: all
 
 -include local.mk
 
-TOOLCHAIN ?= arm-eabi-
+TOOLCHAIN ?= arm-none-eabi-
 
 BOARD ?= panda
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ what_to_build:: all
 
 -include local.mk
 
-TOOLCHAIN ?= arm-none-eabi-
+TOOLCHAIN ?= arm-eabi-
 
 BOARD ?= panda
 

--- a/tools/usbboot.c
+++ b/tools/usbboot.c
@@ -93,21 +93,23 @@ int usb_boot(usb_handle *usb,
 	
 	
 	if (data2) {
-		// reopen the usb endpoint, to switch from talking
-		// to the 1st stage to talk to the 2nd stage 
-		usb_close(usb);
 		fprintf(stderr,"waiting for 2ndstage response...\n");
-		// sleeping for 2 seconds to let the 2nd stage prepare.
-		// if you reopen too quickly then things break, stochastically.
-		sleep(2);
-		usb = usb_open(match_omap4_bootloader);
+		
+		// sleep lets the 2nd stage prepare itself.
+		// if speak to it too quickly it may or may not be ready, and if not it will cut you off.
+		sleep(5);
+		
+		// look for the 2nd stage's "I'm here!" banner
 		usb_read(usb, &msg_size, sizeof(msg_size));
-		// 0xaabbccdd is not any sort of message size.
-		// msg_size was just a convenient piece of RAM available
+		  // msg_size is just a convenient piece of RAM available
+		  // the value we read is not any sort of message size.
 		if (msg_size != 0xaabbccdd) {
-			fprintf(stderr,"unexpected 2ndstage response\n");
+			fprintf(stderr,"unexpected 2ndstage response 0x%08X\n", msg_size);
 			return -1;
 		}
+		
+		// since the 2nd stage looks ready to accept the 3rd,
+		// send it over:
 		msg_size = sz2;
 		fprintf(stderr,"sending image to target...\n");
 		usb_write(usb, &msg_size, sizeof(msg_size));

--- a/trusted.S
+++ b/trusted.S
@@ -7,6 +7,7 @@ call_trusted:
 	dsb
 	isb
 	dmb
+.arch_extension sec
 	smc 1
 	ldmfd sp!, {r4-r12,lr}
 	bx lr


### PR DESCRIPTION
Per #8, I've committed @dmitry-pervushin's fix to the asm code (which I would have had no idea how to fix, so thanks Dimitry), and I've also dug deep with packet sniffers and solved why this version wasn't booting my phone and @wkpark's was: this version was not giving the 2nd stage time to orient itself. The 2nd stage is running on a slower machine than my (and probably your) host, and can be swamped out and confused if you talk to it too quickly; also the USB endpoint should be reopened to notify the 2nd stage that it has someone to talk to; with the `sleep()` but without the reopen, _mostly_ the boot goes properly, but sometimes it fails. Adding the reopen makes it so far 100% reliable for me. Plus [TI does it too](https://gforge.ti.com/gf/project/flash/scmsvn/?action=browse&path=%2Ftrunk%2Fomapflash%2Fhost%2Fpheriphalboot.c&annotate=5#l877).

I hae _not_ edited the Makefile in this patch, because I do not know if the `arm-eabi-` -> `arm-none-eabi-` change was archlinux specific or broader.
